### PR TITLE
Update CLI tool branding

### DIFF
--- a/cli-tool/bin/create-claude-config.js
+++ b/cli-tool/bin/create-claude-config.js
@@ -7,8 +7,8 @@ const { createClaudeConfig } = require('../src/index');
 
 const pkg = require('../package.json');
 
-const title = 'Claude Code Templates';
-const subtitle = 'Your starting point for Claude Code projects';
+const title = 'Claude Code RiskExec.';
+const subtitle = 'Your starting point for Claude Code RiskExec projects';
 
 const colorGradient = ['#EA580C', '#F97316', '#FB923C', '#FDBA74', '#FED7AA', '#FFEBD6'];
 


### PR DESCRIPTION
## Summary
- rename CLI banner title to "Claude Code RiskExec." and update subtitle accordingly

## Testing
- `npm test` *(fails: npm not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ac7f3408321930301389219b79c