### PR TITLE
chore: rename templates references to riskexec

### DIFF
--- a/cli-tool/src/command-stats.js
+++ b/cli-tool/src/command-stats.js
@@ -115,7 +115,7 @@ function displayCommandStats(analysis) {
 
   if (!analysis.exists) {
     console.log(chalk.yellow('⚠️  ' + analysis.message));
-    console.log(chalk.blue('\n💡 Run the setup first: npx claude-code-templates'));
+    console.log(chalk.blue('\n💡 Run the setup first: npx claude-code-riskexec'));
     return false; // Indicate no .claude directory
   }
 
@@ -188,30 +188,30 @@ function displayCommandStats(analysis) {
 }
 
 /**
- * Prompts user to setup Claude Code Templates when no commands are found
+ * Prompts user to setup Claude Code RiskExec when no commands are found
  * @param {string} targetDir - Project directory
  */
 async function promptSetupWhenNoCommands(targetDir) {
   const inquirer = require('inquirer');
   
-  console.log(chalk.cyan('\n🚀 Claude Code Templates Setup'));
-  console.log(chalk.gray('No Claude Code commands found in this project. You can set up Claude Code Templates to get started.'));
+  console.log(chalk.cyan('\n🚀 Claude Code RiskExec Setup'));
+  console.log(chalk.gray('No Claude Code commands found in this project. You can set up Claude Code RiskExec to get started.'));
   
   try {
     const { setupNow } = await inquirer.prompt([{
       type: 'confirm',
       name: 'setupNow',
-      message: 'Would you like to start the Claude Code Templates setup now?',
+      message: 'Would you like to start the Claude Code RiskExec setup now?',
       default: true,
       prefix: chalk.blue('🤖')
     }]);
 
     if (!setupNow) {
-      console.log(chalk.yellow('⏭️  Setup skipped. Run "npx claude-code-templates" anytime to set up your project.'));
+      console.log(chalk.yellow('⏭️  Setup skipped. Run "npx claude-code-riskexec" anytime to set up your project.'));
       return false;
     }
 
-    console.log(chalk.blue('\n🚀 Starting Claude Code Templates setup...'));
+    console.log(chalk.blue('\n🚀 Starting Claude Code RiskExec setup...'));
     console.log(chalk.gray('This will guide you through language and framework selection.\n'));
 
     // Import and run the main setup function
@@ -222,7 +222,7 @@ async function promptSetupWhenNoCommands(targetDir) {
 
   } catch (error) {
     console.error(chalk.red('Error during setup:'), error.message);
-    console.log(chalk.blue('💡 You can run setup manually with: npx claude-code-templates'));
+    console.log(chalk.blue('💡 You can run setup manually with: npx claude-code-riskexec'));
     return false;
   }
 }

--- a/cli-tool/src/file-operations.js
+++ b/cli-tool/src/file-operations.js
@@ -655,7 +655,7 @@ function createValidationPrompt(templateConfig) {
   const language = templateConfig.language || 'unknown';
   const framework = templateConfig.framework || 'none';
   
-  return `Validate Claude Code Templates installation for this ${language}${framework !== 'none' ? ` ${framework}` : ''} project. 1) Check project structure (package.json, src/, etc.) 2) Review CLAUDE.md, .claude/settings.json, .claude/commands/ 3) Compare with actual project dependencies 4) Suggest specific improvements. Make configuration match this project's actual setup.`;
+  return `Validate Claude Code RiskExec installation for this ${language}${framework !== 'none' ? ` ${framework}` : ''} project. 1) Check project structure (package.json, src/, etc.) 2) Review CLAUDE.md, .claude/settings.json, .claude/commands/ 3) Compare with actual project dependencies 4) Suggest specific improvements. Make configuration match this project's actual setup.`;
 }
 
 async function processSettingsFile(sourcePath, destPath, templateConfig) {

--- a/cli-tool/src/hook-stats.js
+++ b/cli-tool/src/hook-stats.js
@@ -172,17 +172,17 @@ async function runHookStats(options) {
   
   if (!analysis) {
     console.log(chalk.yellow('\n💡 No automation hooks found.'));
-    console.log(chalk.gray('Would you like to set up Claude Code Templates to add automation hooks?'));
+    console.log(chalk.gray('Would you like to set up Claude Code RiskExec to add automation hooks?'));
     
     const { setupHooks } = await inquirer.prompt([{
       type: 'confirm',
       name: 'setupHooks',
-      message: 'Set up automation hooks with Claude Code Templates?',
+      message: 'Set up automation hooks with Claude Code RiskExec?',
       default: true
     }]);
 
     if (setupHooks) {
-      console.log(chalk.blue('\n🚀 Starting Claude Code Templates setup...'));
+      console.log(chalk.blue('\n🚀 Starting Claude Code RiskExec setup...'));
       
       // Import and run the main setup
       const createClaudeConfig = require('./index');

--- a/cli-tool/src/mcp-stats.js
+++ b/cli-tool/src/mcp-stats.js
@@ -234,17 +234,17 @@ async function runMCPStats(options) {
   
   if (!analysis) {
     console.log(chalk.yellow('\n💡 No MCP servers found.'));
-    console.log(chalk.gray('Would you like to set up Claude Code Templates to add MCP servers?'));
+    console.log(chalk.gray('Would you like to set up Claude Code RiskExec to add MCP servers?'));
     
     const { setupMCP } = await inquirer.prompt([{
       type: 'confirm',
       name: 'setupMCP',
-      message: 'Set up MCP servers with Claude Code Templates?',
+      message: 'Set up MCP servers with Claude Code RiskExec?',
       default: true
     }]);
 
     if (setupMCP) {
-      console.log(chalk.blue('\n🚀 Starting Claude Code Templates setup...'));
+      console.log(chalk.blue('\n🚀 Starting Claude Code RiskExec setup...'));
       
       // Import and run the main setup
       const createClaudeConfig = require('./index');

--- a/cli-tool/src/sdk/global-agent-manager.js
+++ b/cli-tool/src/sdk/global-agent-manager.js
@@ -128,7 +128,7 @@ async function listGlobalAgents(options = {}) {
     
     if (allAgents.length === 0) {
       console.log(chalk.yellow('⚠️  No global agents installed yet.'));
-      console.log(chalk.gray('💡 Create one with: npx claude-code-templates@latest --create-agent <agent-name>'));
+      console.log(chalk.gray('💡 Create one with: npx claude-code-riskexec@latest --create-agent <agent-name>'));
       return;
     }
     
@@ -159,8 +159,8 @@ async function listGlobalAgents(options = {}) {
     
     console.log(chalk.blue('🌟 Global Usage:'));
     console.log(chalk.gray('  • Run from any directory: <agent-name> "prompt"'));
-    console.log(chalk.gray('  • List agents: npx claude-code-templates@latest --list-agents'));
-    console.log(chalk.gray('  • Remove agent: npx claude-code-templates@latest --remove-agent <name>'));
+    console.log(chalk.gray('  • List agents: npx claude-code-riskexec@latest --list-agents'));
+    console.log(chalk.gray('  • Remove agent: npx claude-code-riskexec@latest --remove-agent <name>'));
     
   } catch (error) {
     console.log(chalk.red(`❌ Error listing agents: ${error.message}`));
@@ -520,7 +520,7 @@ async function addToPath() {
       
       // Add PATH export if not already present
       if (!content.includes(BIN_DIR)) {
-        const newContent = content + `\n# Claude Code Templates - Global Agents\n${pathExport}\n`;
+        const newContent = content + `\n# Claude Code RiskExec - Global Agents\n${pathExport}\n`;
         await fs.writeFile(configFile, newContent, 'utf8');
         console.log(chalk.green(`✅ Updated ${path.basename(configFile)}`));
       }
@@ -629,8 +629,8 @@ async function showAvailableAgents() {
     });
     
     console.log(chalk.blue('Examples:'));
-    console.log(chalk.gray('  npx claude-code-templates@latest --create-agent api-security-audit'));
-    console.log(chalk.gray('  npx claude-code-templates@latest --create-agent deep-research-team/academic-researcher'));
+    console.log(chalk.gray('  npx claude-code-riskexec@latest --create-agent api-security-audit'));
+    console.log(chalk.gray('  npx claude-code-riskexec@latest --create-agent deep-research-team/academic-researcher'));
     
   } catch (error) {
     console.log(chalk.red('❌ Error fetching agents:', error.message));


### PR DESCRIPTION
## Summary
- replace `Claude Code Templates` mentions with `Claude Code RiskExec`
- update CLI usage examples from `claude-code-templates` to `claude-code-riskexec`
- adjust global agent PATH comments for RiskExec

## Testing
- `npm test` (fails: SyntaxError and failing suites)


------
https://chatgpt.com/codex/tasks/task_e_68c37ac575108321965f34889d85e393