### PR TITLE
feat: enforce local host for router

### DIFF
--- a/scripts/router-verify.js
+++ b/scripts/router-verify.js
@@ -10,6 +10,9 @@ if (!fs.existsSync(cfg)) die("Router config missing at ~/.claude-code-router/con
 
 const json = JSON.parse(fs.readFileSync(cfg, "utf8"));
 
+if (json.HOST !== "127.0.0.1")
+    die(`HOST must be "127.0.0.1", found '${json.HOST}'`, 8);
+
 const allowedProviders = new Set(["anthropic"]);
 const bannedProviders = new Set(["openrouter", "iflow", "volcengine", "modelscope", "dashscope"]);
 const allowedModels = new Set(["claude-3.7-sonnet", "claude-3.7-haiku"]);


### PR DESCRIPTION
## Summary
- ensure router config HOST is 127.0.0.1 in verification script

## Testing
- `node scripts/router-verify.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c374c98da48321a2c86a4adc040829