### PR TITLE
Handle JSON parse errors in router verify script

### DIFF
--- a/scripts/router-verify.js
+++ b/scripts/router-verify.js
@@ -8,7 +8,12 @@ function die(msg, code = 1) { console.error(msg); process.exit(code); }
 const cfg = path.join(os.homedir(), ".claude-code-router", "config.json");
 if (!fs.existsSync(cfg)) die("Router config missing at ~/.claude-code-router/config.json", 2);
 
-const json = JSON.parse(fs.readFileSync(cfg, "utf8"));
+let json;
+try {
+    json = JSON.parse(fs.readFileSync(cfg, "utf8"));
+} catch (err) {
+    die(`Failed to parse router config JSON: ${err.message}`, 8);
+}
 
 const allowedProviders = new Set(["anthropic"]);
 const bannedProviders = new Set(["openrouter", "iflow", "volcengine", "modelscope", "dashscope"]);


### PR DESCRIPTION
## Summary
- Prevent crashes when router config contains invalid JSON
- Report parsing issues with a clear message and non-zero exit code

## Testing
- `npm test`
- `npm run policy:router`


------
https://chatgpt.com/codex/tasks/task_e_68c374cef8c48321bacc771946195111