### PR TITLE
docs: update project naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Node.js CLI tool for setting up Claude Code configurations and providing real-time analytics. The project uses modern JavaScript/Node.js development practices and includes a comprehensive analytics dashboard with modular architecture.
+Claude Code RiskExec is a Node.js CLI tool for setting up Claude Code configurations and providing real-time analytics. The project uses modern JavaScript/Node.js development practices and includes a comprehensive analytics dashboard with modular architecture.
 
 ## Development Commands
 
@@ -377,17 +377,17 @@ Automation triggers for development workflows:
 #### CLI Installation Patterns
 ```bash
 # Install specific components
-npx claude-code-templates@latest --agent <name>
-npx claude-code-templates@latest --command <name>
-npx claude-code-templates@latest --mcp <name>
-npx claude-code-templates@latest --setting <name>
-npx claude-code-templates@latest --hook <name>
+npx claude-code-riskexec@latest --agent <name>
+npx claude-code-riskexec@latest --command <name>
+npx claude-code-riskexec@latest --mcp <name>
+npx claude-code-riskexec@latest --setting <name>
+npx claude-code-riskexec@latest --hook <name>
 
 # Batch installation
-npx claude-code-templates@latest --agent security-auditor --command security-audit --setting read-only-mode
+npx claude-code-riskexec@latest --agent security-auditor --command security-audit --setting read-only-mode
 
 # Interactive mode
-npx claude-code-templates@latest
+npx claude-code-riskexec@latest
 ```
 
 #### Special Component Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Claude Code Templates
+# Contributing to Claude Code RiskExec
 
 We welcome contributions! Help us make Claude Code even better for everyone.
 
@@ -285,8 +285,8 @@ For advanced contributors who want to improve the CLI tools like analytics, heal
 #### Project Setup
 ```bash
 # Clone the repository
-git clone https://github.com/davila7/claude-code-templates.git
-cd claude-code-templates
+git clone https://github.com/davila7/claude-code-riskexec.git
+cd claude-code-riskexec
 
 # Navigate to the CLI tool directory
 cd cli-tool
@@ -402,15 +402,15 @@ npm run health-check
 ### Component Testing
 ```bash
 # Test component installation
-npx claude-code-templates@latest --agent your-agent --dry-run
-npx claude-code-templates@latest --command your-command --dry-run
-npx claude-code-templates@latest --mcp your-mcp --dry-run
+npx claude-code-riskexec@latest --agent your-agent --dry-run
+npx claude-code-riskexec@latest --command your-command --dry-run
+npx claude-code-riskexec@latest --mcp your-mcp --dry-run
 ```
 
 ### Template Testing
 ```bash
 # Test template installation
-npx claude-code-templates@latest --template your-template --dry-run
+npx claude-code-riskexec@latest --template your-template --dry-run
 
 # Test with specific scenarios
 npm start -- --language python --framework django --dry-run
@@ -433,8 +433,8 @@ npm run health-check:test
 
 ### 1. Fork and Clone
 ```bash
-git clone https://github.com/your-username/claude-code-templates.git
-cd claude-code-templates
+git clone https://github.com/your-username/claude-code-riskexec.git
+cd claude-code-riskexec
 ```
 
 ### 2. Create Feature Branch
@@ -482,8 +482,8 @@ npm start -- --dry-run
 ## 📞 Getting Help
 
 ### Community Support
-- **GitHub Issues** - [Report bugs or request features](https://github.com/davila7/claude-code-templates/issues)
-- **GitHub Discussions** - [Join community discussions](https://github.com/davila7/claude-code-templates/discussions)
+- **GitHub Issues** - [Report bugs or request features](https://github.com/davila7/claude-code-riskexec/issues)
+- **GitHub Discussions** - [Join community discussions](https://github.com/davila7/claude-code-riskexec/discussions)
 - **Documentation** - [Complete guides at docs.aitmpl.com](https://docs.aitmpl.com/)
 
 ### Quick Start Guides
@@ -502,4 +502,4 @@ All contributors are recognized in our:
 - **Release Notes** for significant contributions  
 - **Community Discussions** for helpful contributions
 
-Thank you for helping make Claude Code Templates better for everyone! 🚀
+Thank you for helping make Claude Code RiskExec better for everyone! 🚀

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# 🚀 Claude Code Templates - Roadmap
+# 🚀 Claude Code RiskExec - Roadmap
 
 ```
  ██████╗██╗      █████╗ ██╗   ██╗██████╗ ███████╗     ██████╗ ██████╗ ██████╗ ███████╗
@@ -18,7 +18,7 @@
 
 ## 📋 Development Roadmap 
 
-> **Mission**: Transform Claude Code Templates into the definitive marketplace for AI-powered development tools and workflows.
+> **Mission**: Transform Claude Code RiskExec into the definitive marketplace for AI-powered development tools and workflows.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Thank you for helping us keep Claude Code Templates and the systems they interact with secure.
+Thank you for helping us keep Claude Code RiskExec and the systems they interact with secure.
 
 ## Reporting Security Issues
 
@@ -10,13 +10,13 @@ The security of our CLI tool and the templates it generates is our top priority.
 
 ## How to Report a Vulnerability
 
-If you discover a security vulnerability in Claude Code Templates, please report it to us in one of the following ways:
+If you discover a security vulnerability in Claude Code RiskExec, please report it to us in one of the following ways:
 
 ### Email
-Send details of the vulnerability to [dan.avila7@gmail.com](mailto:dan.avila7@gmail.com) with the subject line "SECURITY: Claude Code Templates Vulnerability Report"
+Send details of the vulnerability to [dan.avila7@gmail.com](mailto:dan.avila7@gmail.com) with the subject line "SECURITY: Claude Code RiskExec Vulnerability Report"
 
 ### GitHub Security Advisories
-You can also report vulnerabilities through [GitHub Security Advisories](https://github.com/davila7/claude-code-templates/security/advisories/new) for this repository.
+You can also report vulnerabilities through [GitHub Security Advisories](https://github.com/davila7/claude-code-riskexec/security/advisories/new) for this repository.
 
 ## What to Include in Your Report
 
@@ -31,10 +31,10 @@ To help us understand and resolve the issue quickly, please include:
 
 ## Security Best Practices
 
-When using Claude Code Templates:
+When using Claude Code RiskExec:
 
 ### For Users
-- **Keep Updated**: Always use the latest version via `npx claude-code-templates@latest`
+- **Keep Updated**: Always use the latest version via `npx claude-code-riskexec@latest`
 - **Review Templates**: Check generated files before committing to your repository
 - **Audit Hooks**: Review automation hooks before enabling them
 - **Secure Environment**: Use the tool in a secure development environment
@@ -62,4 +62,4 @@ This security policy is designed to encourage responsible security research. We 
 - Do not perform testing on systems they do not own
 - Report vulnerabilities through the channels described above
 
-Thank you for helping keep Claude Code Templates secure!
+Thank you for helping keep Claude Code RiskExec secure!


### PR DESCRIPTION
## Summary
- update SECURITY, CONTRIBUTING, ROADMAP, and CLAUDE guides to reference Claude Code RiskExec
- switch all example commands to `npx claude-code-riskexec`
- point repository links to `claude-code-riskexec`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c37ab8bba883218f64e9eacb7d7bc1