### PR TITLE
Use __dirname for router config and tighten file permissions

### DIFF
--- a/scripts/router-install.js
+++ b/scripts/router-install.js
@@ -3,7 +3,9 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
-const src = path.join(process.cwd(), ".claude-code-router", "config.json");
+// Resolve the source path relative to this script's directory so it does not
+// depend on the current working directory when executed.
+const src = path.resolve(__dirname, "..", ".claude-code-router", "config.json");
 const dstDir = path.join(os.homedir(), ".claude-code-router");
 const dst = path.join(dstDir, "config.json");
 
@@ -20,6 +22,8 @@ if (fs.existsSync(dst)) {
 }
 
 fs.copyFileSync(src, dst);
+// Restrict permissions to the owner after writing the file
+fs.chmodSync(dst, 0o600);
 console.log(`Wrote ${dst}`);
 
 console.log("\nSet env vars before running the router:");


### PR DESCRIPTION
## Summary
- Resolve `.claude-code-router` path relative to script using `__dirname` to avoid dependence on `process.cwd()`
- Set copied router config to owner-only permissions with `fs.chmodSync`

## Testing
- `npm test`
- `npm run policy:all` *(fails: incomplete explicit mapping pair; a key node is missed)*

------
https://chatgpt.com/codex/tasks/task_e_68c374db0974832198f845390c7b0428