### PR TITLE
docs: rename templates references to riskexec

### DIFF
--- a/docu/docs/analytics/agent-chats-manager.md
+++ b/docu/docs/analytics/agent-chats-manager.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Agent Chats Manager
 
-The Agent Chats Manager within the `claude-code-templates` analytics dashboard allows you to monitor and analyze Claude agent interactions in real-time. This provides a clear visual flow of how Claude Code processes information and responds.
+The Agent Chats Manager within the `claude-code-riskexec` analytics dashboard allows you to monitor and analyze Claude agent interactions in real-time. This provides a clear visual flow of how Claude Code processes information and responds.
 
 ## How it Works
 

--- a/docu/docs/analytics/analysis-tools.md
+++ b/docu/docs/analytics/analysis-tools.md
@@ -4,14 +4,14 @@ sidebar_position: 4
 
 # Analysis Tools
 
-The `claude-code-templates` CLI provides dedicated analysis tools to help you understand and optimize your existing Claude Code configurations. These tools offer insights into your commands, automation hooks, and MCP server configurations.
+The `claude-code-riskexec` CLI provides dedicated analysis tools to help you understand and optimize your existing Claude Code configurations. These tools offer insights into your commands, automation hooks, and MCP server configurations.
 
 ## Command Analysis
 
 View detailed statistics about your custom commands:
 
 ```bash
-npx claude-code-templates --commands-stats
+npx claude-code-riskexec --commands-stats
 ```
 
 **What you get:**
@@ -26,7 +26,7 @@ npx claude-code-templates --commands-stats
 Analyze your automation hooks configuration:
 
 ```bash
-npx claude-code-templates --hooks-stats
+npx claude-code-riskexec --hooks-stats
 ```
 
 **What you get:**
@@ -42,7 +42,7 @@ npx claude-code-templates --hooks-stats
 Analyze your MCP server configurations:
 
 ```bash
-npx claude-code-templates --mcps-stats
+npx claude-code-riskexec --mcps-stats
 ```
 
 **What you get:**

--- a/docu/docs/analytics/overview.md
+++ b/docu/docs/analytics/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Analytics Dashboard Overview
 
-The `claude-code-templates` CLI includes a comprehensive analytics dashboard that allows you to monitor and optimize your Claude Code agents and interactions in real-time. This dashboard provides valuable insights into usage patterns, performance metrics, and conversation history.
+The `claude-code-riskexec` CLI includes a comprehensive analytics dashboard that allows you to monitor and optimize your Claude Code agents and interactions in real-time. This dashboard provides valuable insights into usage patterns, performance metrics, and conversation history.
 
 ## Key Features of the Analytics Dashboard
 
@@ -40,9 +40,9 @@ graph TD
 You can launch the analytics dashboard using the following command:
 
 ```bash
-npx claude-code-templates --analytics
+npx claude-code-riskexec --analytics
 # or
-npx claude-code-templates --chats
+npx claude-code-riskexec --chats
 ```
 
 Once launched, you can access the web interface in your browser at `http://localhost:3333`.

--- a/docu/docs/analytics/real-time-monitoring.md
+++ b/docu/docs/analytics/real-time-monitoring.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Real-time Monitoring
 
-The `claude-code-templates` analytics dashboard provides robust real-time monitoring capabilities to keep you informed about your Claude Code interactions as they happen.
+The `claude-code-riskexec` analytics dashboard provides robust real-time monitoring capabilities to keep you informed about your Claude Code interactions as they happen.
 
 ## Features
 

--- a/docu/docs/cli-options.md
+++ b/docu/docs/cli-options.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # CLI Options Reference
 
-This section provides a comprehensive reference of all available command-line options for `claude-code-templates`.
+This section provides a comprehensive reference of all available command-line options for `claude-code-riskexec`.
 
 ## Template and Component Options
 
@@ -51,31 +51,31 @@ This section provides a comprehensive reference of all available command-line op
 ### Modern Template Installation (Recommended)
 ```bash
 # Install React template with all components
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 
 # Install Python template with all components
-npx claude-code-templates@latest --template=python --yes
+npx claude-code-riskexec@latest --template=python --yes
 
 # Install Node.js template with all components
-npx claude-code-templates@latest --template=nodejs --yes
+npx claude-code-riskexec@latest --template=nodejs --yes
 ```
 
 ### Individual Component Installation
 ```bash
 # Install specific agent
-npx claude-code-templates@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
 
 # Install specific command
-npx claude-code-templates@latest --command=check-file --yes
+npx claude-code-riskexec@latest --command=check-file --yes
 
 # Install specific MCP
-npx claude-code-templates@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
 ```
 
 ### Legacy Syntax (Still Supported)
 ```bash
 # Old syntax - still works but deprecated
-npx claude-code-templates@latest --language=javascript-typescript --framework=react --yes
+npx claude-code-riskexec@latest --language=javascript-typescript --framework=react --yes
 ```
 
 ## GitHub Download System

--- a/docu/docs/components/agents.md
+++ b/docu/docs/components/agents.md
@@ -26,13 +26,13 @@ Agents extend Claude Code's capabilities by providing:
 
 ```bash
 # Install specific agent using new CLI parameter (recommended)
-npx claude-code-templates@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
 
 # Or install via complete template
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 
 # Legacy syntax (still supported)
-npx claude-code-templates@latest --language=javascript-typescript --framework=react
+npx claude-code-riskexec@latest --language=javascript-typescript --framework=react
 ```
 
 #### Vue.js Development Assistant  
@@ -103,11 +103,11 @@ Install specific agents using the `--agent` parameter:
 
 ```bash
 # Install specific agents directly
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --agent=api-security-audit --yes
-npx claude-code-templates@latest --agent=database-optimization --yes
-npx claude-code-templates@latest --agent=vue-development --yes
-npx claude-code-templates@latest --agent=docker-expert --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --agent=api-security-audit --yes
+npx claude-code-riskexec@latest --agent=database-optimization --yes
+npx claude-code-riskexec@latest --agent=vue-development --yes
+npx claude-code-riskexec@latest --agent=docker-expert --yes
 ```
 
 ### Via Template Installation
@@ -115,16 +115,16 @@ Agents are also included in complete template installations:
 
 ```bash
 # React template includes performance optimization agent
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 
 # Python template includes API security agent
-npx claude-code-templates@latest --template=python --yes
+npx claude-code-riskexec@latest --template=python --yes
 
 # Node.js template includes database optimization agent  
-npx claude-code-templates@latest --template=nodejs --yes
+npx claude-code-riskexec@latest --template=nodejs --yes
 
 # Legacy syntax (still supported but deprecated)
-npx claude-code-templates@latest --language=javascript-typescript --framework=react
+npx claude-code-riskexec@latest --language=javascript-typescript --framework=react
 ```
 
 ### Manual Agent Configuration

--- a/docu/docs/components/commands.md
+++ b/docu/docs/components/commands.md
@@ -240,11 +240,11 @@ Install commands using the `--command` parameter:
 
 ```bash
 # Install specific commands directly
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --command=generate-tests --yes
-npx claude-code-templates@latest --command=optimize-imports --yes
-npx claude-code-templates@latest --command=create-component --yes
-npx claude-code-templates@latest --command=bundle-analysis --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --command=generate-tests --yes
+npx claude-code-riskexec@latest --command=optimize-imports --yes
+npx claude-code-riskexec@latest --command=create-component --yes
+npx claude-code-riskexec@latest --command=bundle-analysis --yes
 ```
 
 ### Direct Download Method (Alternative)
@@ -256,13 +256,11 @@ mkdir -p .claude/commands
 
 # Install specific commands via direct download
 curl -o .claude/commands/check-file.md \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/commands/check-file.md
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/commands/utilities/check-file.md
 
 curl -o .claude/commands/generate-tests.md \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/commands/generate-tests.md
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/commands/testing/generate-tests.md
 
-curl -o .claude/commands/optimize-imports.md \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/commands/optimize-imports.md
 ```
 
 ### Batch Installation
@@ -270,23 +268,23 @@ Install multiple commands using CLI parameters:
 
 ```bash
 # Install multiple commands using CLI parameters (recommended)
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --command=generate-tests --yes
-npx claude-code-templates@latest --command=run-tests --yes
-npx claude-code-templates@latest --command=create-component --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --command=generate-tests --yes
+npx claude-code-riskexec@latest --command=run-tests --yes
+npx claude-code-riskexec@latest --command=create-component --yes
 
 # Or install via direct download (alternative)
 commands=("check-file" "generate-tests" "run-tests" "create-component")
 for cmd in "${commands[@]}"; do
   curl -o .claude/commands/${cmd}.md \
-    https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/commands/${cmd}.md
+    https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/commands/${cmd}.md
 done
 ```
 
 ### Via Web Interface
 Browse and install commands through the unified interface:
 
-1. Run `npx claude-code-templates@latest`
+1. Run `npx claude-code-riskexec@latest`
 2. Select "⚙️ Project Setup"
 3. Filter by "Commands" in the navigation
 4. Click on command cards to see installation instructions

--- a/docu/docs/components/discord-notifications.md
+++ b/docu/docs/components/discord-notifications.md
@@ -15,13 +15,13 @@ Get instant Discord notifications when Claude Code finishes working.
 
 ```bash
 # Basic notifications
-npx claude-code-templates@latest --hook automation/discord-notifications
+npx claude-code-riskexec@latest --hook automation/discord-notifications
 
 # Rich embed notifications with session details
-npx claude-code-templates@latest --hook automation/discord-detailed-notifications
+npx claude-code-riskexec@latest --hook automation/discord-detailed-notifications
 
 # Long operation monitoring
-npx claude-code-templates@latest --hook automation/discord-error-notifications
+npx claude-code-riskexec@latest --hook automation/discord-error-notifications
 ```
 
 ### 3. Set Environment Variable

--- a/docu/docs/components/hooks.md
+++ b/docu/docs/components/hooks.md
@@ -136,13 +136,13 @@ Like settings, hooks support the full Claude Code configuration hierarchy:
 ### Using CLI (Recommended)
 ```bash
 # Install with interactive location selection
-npx claude-code-templates@latest --hook=git-workflow/auto-git-add
+npx claude-code-riskexec@latest --hook=git-workflow/auto-git-add
 
 # Install multiple hooks
-npx claude-code-templates@latest --hook=development-tools/file-backup,automation/simple-notifications
+npx claude-code-riskexec@latest --hook=development-tools/file-backup,automation/simple-notifications
 
 # Skip location prompt (defaults to local settings)
-npx claude-code-templates@latest --hook=testing/test-runner --yes
+npx claude-code-riskexec@latest --hook=testing/test-runner --yes
 ```
 
 ### Installation Flow
@@ -158,40 +158,40 @@ When installing hooks, you'll choose the installation location:
 ### Basic File Operations
 ```bash
 # Backup files before editing
-npx claude-code-templates@latest --hook=development-tools/file-backup
+npx claude-code-riskexec@latest --hook=development-tools/file-backup
 
 # Track all file changes
-npx claude-code-templates@latest --hook=development-tools/change-tracker
+npx claude-code-riskexec@latest --hook=development-tools/change-tracker
 
 # Auto-format code after editing
-npx claude-code-templates@latest --hook=development-tools/smart-formatting
+npx claude-code-riskexec@latest --hook=development-tools/smart-formatting
 ```
 
 ### Git Integration
 ```bash
 # Automatically stage changes
-npx claude-code-templates@latest --hook=git-workflow/auto-git-add
+npx claude-code-riskexec@latest --hook=git-workflow/auto-git-add
 
 # Generate smart commits
-npx claude-code-templates@latest --hook=git-workflow/smart-commit
+npx claude-code-riskexec@latest --hook=git-workflow/smart-commit
 ```
 
 ### Automation & Notifications
 ```bash
 # Get desktop notifications
-npx claude-code-templates@latest --hook=automation/simple-notifications
+npx claude-code-riskexec@latest --hook=automation/simple-notifications
 
 # Telegram integration (requires bot setup)
-npx claude-code-templates@latest --hook=automation/telegram-notifications
+npx claude-code-riskexec@latest --hook=automation/telegram-notifications
 ```
 
 ### Security & Performance
 ```bash
 # Protect sensitive files
-npx claude-code-templates@latest --hook=security/file-protection
+npx claude-code-riskexec@latest --hook=security/file-protection
 
 # Monitor performance
-npx claude-code-templates@latest --hook=performance/performance-monitor
+npx claude-code-riskexec@latest --hook=performance/performance-monitor
 ```
 
 ## Environment Variables
@@ -278,7 +278,7 @@ Hooks follow the official Claude Code specification:
 
 4. **Install Hook**:
    ```bash
-   npx claude-code-templates@latest --hook=automation/telegram-notifications
+   npx claude-code-riskexec@latest --hook=automation/telegram-notifications
    ```
 
 ### Custom File Processing
@@ -378,4 +378,3 @@ Want to create your own hook? Follow these guidelines:
 - [Browse All Hooks](https://aitmpl.com) - View available hooks in the web interface
 - [Automation Hooks Guide →](../project-setup/automation-hooks) - Deep dive into automation workflows
 - [Contributing Guide →](../contributing) - Add your own hooks to the collection
-- [Telegram Setup Guide →](https://github.com/davila7/claude-code-templates/blob/main/cli-tool/components/hooks/automation/TELEGRAM_SETUP.md) - Detailed Telegram integration guide

--- a/docu/docs/components/mcps.md
+++ b/docu/docs/components/mcps.md
@@ -82,7 +82,6 @@ MCPs are standardized integrations that allow Claude Code to:
 **Configuration Example**:
 ```json
 {
-  "name": "database-integration",
   "type": "mcp",
   "config": {
     "connections": {
@@ -247,11 +246,10 @@ Install MCPs using the `--mcp` parameter:
 
 ```bash
 # Install specific MCPs directly
-npx claude-code-templates@latest --mcp=github-integration --yes
-npx claude-code-templates@latest --mcp=database-integration --yes
-npx claude-code-templates@latest --mcp=deepgraph-react --yes
-npx claude-code-templates@latest --mcp=aws-integration --yes
-npx claude-code-templates@latest --mcp=docker-integration --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --mcp=deepgraph-react --yes
+npx claude-code-riskexec@latest --mcp=aws-integration --yes
+npx claude-code-riskexec@latest --mcp=docker-integration --yes
 ```
 
 ### Direct Installation Method (Alternative)
@@ -260,15 +258,12 @@ MCPs can also be installed as JSON configuration files via direct download:
 ```bash
 # Install GitHub integration MCP
 curl -o ./github-integration.json \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/mcps/github-integration.json
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/mcps/integration/github-integration.json
 
-# Install database integration MCP
-curl -o ./database-integration.json \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/mcps/database-integration.json
 
 # Install DeepGraph React MCP
 curl -o ./deepgraph-react.json \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/mcps/deepgraph-react.json
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/mcps/deepgraph/deepgraph-react.json
 ```
 
 ### Configuration Management

--- a/docu/docs/components/overview.md
+++ b/docu/docs/components/overview.md
@@ -41,7 +41,6 @@ MCPs enable Claude Code to interact with external services and tools, expanding 
 
 **Examples:**
 - `github-integration` - Direct GitHub repository interactions
-- `database-integration` - Connect to and query databases directly
 - `deepgraph-react` - Advanced React component analysis and visualization
 
 [Learn more about MCPs →](./mcps)
@@ -89,8 +88,8 @@ To access the web interface, simply go to https://aitmpl.com
 
 | Method | Use Case | Installation |
 |--------|----------|-------------|
-| **Complete Templates** | Full project setup with multiple components | `npx claude-code-templates@latest --template=react --yes` |
-| **Individual Components** | Selective component installation | `npx claude-code-templates@latest --agent=name --yes` |
+| **Complete Templates** | Full project setup with multiple components | `npx claude-code-riskexec@latest --template=react --yes` |
+| **Individual Components** | Selective component installation | `npx claude-code-riskexec@latest --agent=name --yes` |
 
 ### Installation Commands by Type
 
@@ -99,15 +98,15 @@ Agents can now be installed individually using the `--agent` parameter:
 
 ```bash
 # Install specific agents directly
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --agent=api-security-audit --yes
-npx claude-code-templates@latest --agent=database-optimization --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --agent=api-security-audit --yes
+npx claude-code-riskexec@latest --agent=database-optimization --yes
 
 # Install complete template with all agents
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 
 # Or browse available agents in the web interface
-npx claude-code-templates@latest
+npx claude-code-riskexec@latest
 ```
 
 #### Installing Commands
@@ -115,9 +114,9 @@ Commands can now be installed using the `--command` parameter or manually:
 
 ```bash
 # Install specific commands using CLI parameter (recommended)
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --command=generate-tests --yes
-npx claude-code-templates@latest --command=optimize-imports --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --command=generate-tests --yes
+npx claude-code-riskexec@latest --command=optimize-imports --yes
 
 # Manual installation (alternative method)
 # Create commands directory first
@@ -125,10 +124,10 @@ mkdir -p .claude/commands
 
 # Download specific commands
 curl -o .claude/commands/check-file.md \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/commands/check-file.md
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/commands/utilities/check-file.md
 
 curl -o .claude/commands/generate-tests.md \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/commands/generate-tests.md
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/commands/testing/generate-tests.md
 ```
 
 #### Installing MCPs
@@ -136,17 +135,14 @@ MCPs can now be installed using the `--mcp` parameter or manually:
 
 ```bash
 # Install specific MCPs using CLI parameter (recommended)
-npx claude-code-templates@latest --mcp=github-integration --yes
-npx claude-code-templates@latest --mcp=database-integration --yes
-npx claude-code-templates@latest --mcp=deepgraph-react --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --mcp=deepgraph-react --yes
 
 # Manual installation (alternative method)
 # Download specific MCPs
 curl -o ./github-integration.json \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/mcps/github-integration.json
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/mcps/integration/github-integration.json
 
-curl -o ./database-integration.json \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/mcps/database-integration.json
 ```
 
 #### Installing Settings
@@ -154,15 +150,15 @@ Settings can be installed using the `--setting` parameter with interactive locat
 
 ```bash
 # Install specific settings with location prompt
-npx claude-code-templates@latest --setting=permissions/allow-npm-commands
-npx claude-code-templates@latest --setting=model/use-sonnet
-npx claude-code-templates@latest --setting=telemetry/enable-telemetry
+npx claude-code-riskexec@latest --setting=permissions/allow-npm-commands
+npx claude-code-riskexec@latest --setting=model/use-sonnet
+npx claude-code-riskexec@latest --setting=telemetry/enable-telemetry
 
 # Install to default location (local settings)
-npx claude-code-templates@latest --setting=cleanup/retention-7-days --yes
+npx claude-code-riskexec@latest --setting=cleanup/retention-7-days --yes
 
 # Install multiple settings
-npx claude-code-templates@latest --setting=model/use-sonnet,telemetry/enable-telemetry --yes
+npx claude-code-riskexec@latest --setting=model/use-sonnet,telemetry/enable-telemetry --yes
 ```
 
 **Installation Location Options:**
@@ -176,15 +172,15 @@ Hooks can be installed using the `--hook` parameter with location selection:
 
 ```bash
 # Install specific hooks with location prompt
-npx claude-code-templates@latest --hook=git-workflow/auto-git-add
-npx claude-code-templates@latest --hook=automation/telegram-notifications
-npx claude-code-templates@latest --hook=development-tools/smart-formatting
+npx claude-code-riskexec@latest --hook=git-workflow/auto-git-add
+npx claude-code-riskexec@latest --hook=automation/telegram-notifications
+npx claude-code-riskexec@latest --hook=development-tools/smart-formatting
 
 # Install to default location (local settings)
-npx claude-code-templates@latest --hook=testing/test-runner --yes
+npx claude-code-riskexec@latest --hook=testing/test-runner --yes
 
 # Install multiple hooks
-npx claude-code-templates@latest --hook=development-tools/file-backup,security/file-protection --yes
+npx claude-code-riskexec@latest --hook=development-tools/file-backup,security/file-protection --yes
 ```
 
 **Hook Categories:**
@@ -215,7 +211,7 @@ npx claude-code-templates@latest --hook=development-tools/file-backup,security/f
 ### Via Web Interface
 The primary way to discover components is through the unified web interface:
 
-1. Run `npx claude-code-templates@latest`
+1. Run `npx claude-code-riskexec@latest`
 2. Select "⚙️ Project Setup"
 3. Browse components with the unified filter system
 4. Use category filters to focus on specific types
@@ -226,11 +222,11 @@ The quickest way to install components is using dedicated CLI parameters:
 
 ```bash
 # Direct component installation
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --mcp=github-integration --yes
-npx claude-code-templates@latest --setting=model/use-sonnet --yes
-npx claude-code-templates@latest --hook=git-workflow/auto-git-add --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --setting=model/use-sonnet --yes
+npx claude-code-riskexec@latest --hook=git-workflow/auto-git-add --yes
 ```
 
 ### Via GitHub Repository

--- a/docu/docs/components/settings.md
+++ b/docu/docs/components/settings.md
@@ -81,13 +81,13 @@ Settings can be installed at different levels of your Claude Code configuration 
 ### Using CLI (Recommended)
 ```bash
 # Install with interactive location selection
-npx claude-code-templates@latest --setting=permissions/allow-npm-commands
+npx claude-code-riskexec@latest --setting=permissions/allow-npm-commands
 
 # Install multiple settings
-npx claude-code-templates@latest --setting=model/use-sonnet,telemetry/enable-telemetry
+npx claude-code-riskexec@latest --setting=model/use-sonnet,telemetry/enable-telemetry
 
 # Skip location prompt with --yes (defaults to local settings)
-npx claude-code-templates@latest --setting=cleanup/retention-7-days --yes
+npx claude-code-riskexec@latest --setting=cleanup/retention-7-days --yes
 ```
 
 ### Installation Flow
@@ -103,37 +103,37 @@ When you install a setting, you'll be prompted to choose the installation locati
 ### Basic Permission Setup
 ```bash
 # Allow npm commands in this project
-npx claude-code-templates@latest --setting=permissions/allow-npm-commands
+npx claude-code-riskexec@latest --setting=permissions/allow-npm-commands
 
 # Prevent modification of sensitive files globally
-npx claude-code-templates@latest --setting=permissions/deny-sensitive-files
+npx claude-code-riskexec@latest --setting=permissions/deny-sensitive-files
 ```
 
 ### Model Configuration
 ```bash
 # Use Claude 3.5 Sonnet for this project
-npx claude-code-templates@latest --setting=model/use-sonnet
+npx claude-code-riskexec@latest --setting=model/use-sonnet
 
 # Use Claude 3 Haiku for faster responses
-npx claude-code-templates@latest --setting=model/use-haiku
+npx claude-code-riskexec@latest --setting=model/use-haiku
 ```
 
 ### Telemetry Management
 ```bash
 # Enable telemetry for usage analytics
-npx claude-code-templates@latest --setting=telemetry/enable-telemetry
+npx claude-code-riskexec@latest --setting=telemetry/enable-telemetry
 
 # Disable all telemetry collection
-npx claude-code-templates@latest --setting=telemetry/disable-telemetry
+npx claude-code-riskexec@latest --setting=telemetry/disable-telemetry
 ```
 
 ### Cleanup Policies
 ```bash
 # Set 7-day retention policy
-npx claude-code-templates@latest --setting=cleanup/retention-7-days
+npx claude-code-riskexec@latest --setting=cleanup/retention-7-days
 
 # Set 90-day retention for long-term projects
-npx claude-code-templates@latest --setting=cleanup/retention-90-days
+npx claude-code-riskexec@latest --setting=cleanup/retention-90-days
 ```
 
 ## Setting Structure

--- a/docu/docs/components/slack-notifications.md
+++ b/docu/docs/components/slack-notifications.md
@@ -23,13 +23,13 @@ Get instant Slack notifications when Claude Code finishes working.
 
 ```bash
 # Basic notifications
-npx claude-code-templates@latest --hook automation/slack-notifications
+npx claude-code-riskexec@latest --hook automation/slack-notifications
 
 # Rich block notifications with session details
-npx claude-code-templates@latest --hook automation/slack-detailed-notifications
+npx claude-code-riskexec@latest --hook automation/slack-detailed-notifications
 
 # Long operation monitoring
-npx claude-code-templates@latest --hook automation/slack-error-notifications
+npx claude-code-riskexec@latest --hook automation/slack-error-notifications
 ```
 
 ### 4. Set Environment Variable

--- a/docu/docs/components/telegram-notifications.md
+++ b/docu/docs/components/telegram-notifications.md
@@ -26,13 +26,13 @@ Get instant Telegram notifications when Claude Code finishes working.
 
 ```bash
 # Basic notifications
-npx claude-code-templates@latest --hook automation/telegram-notifications
+npx claude-code-riskexec@latest --hook automation/telegram-notifications
 
 # Detailed notifications with session info
-npx claude-code-templates@latest --hook automation/telegram-detailed-notifications
+npx claude-code-riskexec@latest --hook automation/telegram-detailed-notifications
 
 # Long operation monitoring
-npx claude-code-templates@latest --hook automation/telegram-error-notifications
+npx claude-code-riskexec@latest --hook automation/telegram-error-notifications
 ```
 
 ### 4. Set Environment Variables

--- a/docu/docs/contributing.md
+++ b/docu/docs/contributing.md
@@ -6,6 +6,6 @@ sidebar_position: 1
 
 We welcome contributions from the open source community! This project thrives on community input and collaboration.
 
-**Please read our [Code of Conduct](https://github.com/davila7/claude-code-templates/blob/main/CODE_OF_CONDUCT.md) before contributing to ensure a welcoming environment for everyone.**
+**Please read our [Code of Conduct](https://github.com/davila7/claude-code-riskexec/blob/main/CODE_OF_CONDUCT.md) before contributing to ensure a welcoming environment for everyone.**
 
-**See [CONTRIBUTING.md](https://github.com/davila7/claude-code-templates/blob/main/CONTRIBUTING.md) for detailed guidelines**
+**See [CONTRIBUTING.md](https://github.com/davila7/claude-code-riskexec/blob/main/CONTRIBUTING.md) for detailed guidelines**

--- a/docu/docs/health-check/overview.md
+++ b/docu/docs/health-check/overview.md
@@ -4,20 +4,20 @@ sidebar_position: 1
 
 # Health Check Overview
 
-The `claude-code-templates` CLI provides a comprehensive health check feature to validate your Claude Code configuration and system environment. This ensures that your setup is optimal for running Claude Code and helps identify any potential issues.
+The `claude-code-riskexec` CLI provides a comprehensive health check feature to validate your Claude Code configuration and system environment. This ensures that your setup is optimal for running Claude Code and helps identify any potential issues.
 
 ## Running the Health Check
 
 You can run the comprehensive diagnostics on your Claude Code setup using the following command:
 
 ```bash
-npx claude-code-templates --health-check
+npx claude-code-riskexec --health-check
 # or
-npx claude-code-templates --health
+npx claude-code-riskexec --health
 # or
-npx claude-code-templates --check
+npx claude-code-riskexec --check
 # or
-npx claude-code-templates --verify
+npx claude-code-riskexec --verify
 ```
 
 ## What the Health Check Analyzes

--- a/docu/docs/intro.md
+++ b/docu/docs/intro.md
@@ -8,12 +8,12 @@ sidebar_position: 1
 
 ## Key Functionalities
 
-The core functionality of `claude-code-templates` revolves around these key areas:
+The core functionality of `claude-code-riskexec` revolves around these key areas:
 
 ```bash
-npx claude-code-templates@latest
+npx claude-code-riskexec@latest
 # Or use the new template-specific syntax:
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 ```
 
 ### 🚀 Project Setup & Configuration
@@ -55,32 +55,32 @@ Environment and configuration validation:
 ### 1. Modern Template Installation (Recommended)
 ```bash
 # Quick template installation with new syntax
-npx claude-code-templates@latest --template=react --yes
-npx claude-code-templates@latest --template=python --yes
-npx claude-code-templates@latest --template=nodejs --yes
+npx claude-code-riskexec@latest --template=react --yes
+npx claude-code-riskexec@latest --template=python --yes
+npx claude-code-riskexec@latest --template=nodejs --yes
 
 # Or use interactive setup for guidance
 cd your-project-directory
-npx claude-code-templates@latest
+npx claude-code-riskexec@latest
 ```
 
 ### 2. Individual Component Installation
 ```bash
 # Install specific components using new CLI parameters
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
 ```
 
 ### 3. Launch Real-time Analytics Dashboard
 ```bash
-npx claude-code-templates --analytics
+npx claude-code-riskexec --analytics
 # This will launch the real-time monitoring dashboard, accessible at http://localhost:3333.
 ```
 
 ### 4. Run Comprehensive Health Check
 ```bash
-npx claude-code-templates --health-check
+npx claude-code-riskexec --health-check
 # This command performs a comprehensive system validation and provides optimization recommendations.
 ```
 

--- a/docu/docs/project-setup/automation-hooks.md
+++ b/docu/docs/project-setup/automation-hooks.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Automation Hooks
 
-Automation hooks in `claude-code-templates` allow you to execute custom actions at key moments during the Claude Code workflow. This enables powerful automation and integration with your existing development processes.
+Automation hooks in `claude-code-riskexec` allow you to execute custom actions at key moments during the Claude Code workflow. This enables powerful automation and integration with your existing development processes.
 
 ## Types of Hooks
 

--- a/docu/docs/project-setup/framework-specific-setup.md
+++ b/docu/docs/project-setup/framework-specific-setup.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Framework-Specific Setup
 
-While the interactive setup is recommended, you can also quickly configure `claude-code-templates` for specific templates using the modern `--template` parameter or legacy `--language`/`--framework` commands.
+While the interactive setup is recommended, you can also quickly configure `claude-code-riskexec` for specific templates using the modern `--template` parameter or legacy `--language`/`--framework` commands.
 
 ## Modern Template Installation (Recommended)
 
@@ -12,19 +12,19 @@ Use the new `--template` parameter for streamlined template installation:
 
 ```bash
 # React project with all components
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 
 # Python project with all components
-npx claude-code-templates@latest --template=python --yes
+npx claude-code-riskexec@latest --template=python --yes
 
 # Node.js project with all components
-npx claude-code-templates@latest --template=nodejs --yes
+npx claude-code-riskexec@latest --template=nodejs --yes
 
 # Vue.js project with all components
-npx claude-code-templates@latest --template=vue --yes
+npx claude-code-riskexec@latest --template=vue --yes
 
 # Django project with all components
-npx claude-code-templates@latest --template=django --yes
+npx claude-code-riskexec@latest --template=django --yes
 ```
 
 ## Legacy Syntax (Still Supported)
@@ -33,10 +33,10 @@ The original `--language` and `--framework` flags are still supported but deprec
 
 ```bash
 # React + TypeScript project (legacy)
-npx claude-code-templates@latest --language=javascript-typescript --framework=react --yes
+npx claude-code-riskexec@latest --language=javascript-typescript --framework=react --yes
 
 # Python + Django project (legacy)
-npx claude-code-templates@latest --language=python --framework=django --yes
+npx claude-code-riskexec@latest --language=python --framework=django --yes
 ```
 
 **Note**: These legacy parameters will continue to work but using `--template` is preferred for new installations.
@@ -49,7 +49,7 @@ Even when you know your framework, running the tool without specific flags is of
 
 ```bash
 cd my-react-app
-npx claude-code-templates@latest
+npx claude-code-riskexec@latest
 # The tool will auto-detect React and suggest optimal configuration
 ```
 
@@ -67,13 +67,13 @@ You can also install individual components instead of complete templates:
 
 ```bash
 # Install specific agent
-npx claude-code-templates@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
 
 # Install specific command
-npx claude-code-templates@latest --command=check-file --yes
+npx claude-code-riskexec@latest --command=check-file --yes
 
 # Install specific MCP
-npx claude-code-templates@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
 ```
 
 ## GitHub Download System

--- a/docu/docs/project-setup/interactive-setup.md
+++ b/docu/docs/project-setup/interactive-setup.md
@@ -4,14 +4,14 @@ sidebar_position: 1
 
 # Interactive Project Setup
 
-The `claude-code-templates` CLI provides an interactive way to set up and configure your projects for Claude Code. This is the recommended way to get started.
+The `claude-code-riskexec` CLI provides an interactive way to set up and configure your projects for Claude Code. This is the recommended way to get started.
 
 ## Quick Start
 
 To begin, navigate to your project directory and run the following command:
 
 ```bash
-npx claude-code-templates@latest
+npx claude-code-riskexec@latest
 ```
 
 You'll be greeted with an interactive welcome screen:

--- a/docu/docs/project-setup/supported-languages-frameworks.md
+++ b/docu/docs/project-setup/supported-languages-frameworks.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Supported Languages & Frameworks
 
-`claude-code-templates` is designed to support a wide range of programming languages and frameworks, providing tailored configurations and commands for each. The following table outlines the current status of support:
+`claude-code-riskexec` is designed to support a wide range of programming languages and frameworks, providing tailored configurations and commands for each. The following table outlines the current status of support:
 
 | Language | Frameworks | Status | Commands | Hooks | MCP |
 |----------|------------|---------|----------|--------|-----|

--- a/docu/docs/project-setup/what-gets-installed.md
+++ b/docu/docs/project-setup/what-gets-installed.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # What Gets Installed
 
-When you use `claude-code-templates` to set up your project, it installs several core files and configurations to integrate Claude Code effectively into your development environment. You can choose between **complete templates** (comprehensive project setup) or **individual components** (selective functionality).
+When you use `claude-code-riskexec` to set up your project, it installs several core files and configurations to integrate Claude Code effectively into your development environment. You can choose between **complete templates** (comprehensive project setup) or **individual components** (selective functionality).
 
 ## Installation Methods
 
@@ -13,15 +13,15 @@ For comprehensive project setup with all recommended components:
 
 ```bash
 # Interactive setup (recommended)
-npx claude-code-templates@latest
+npx claude-code-riskexec@latest
 
 # Modern template installation (preferred)
-npx claude-code-templates@latest --template=react --yes
-npx claude-code-templates@latest --template=python --yes
-npx claude-code-templates@latest --template=nodejs --yes
+npx claude-code-riskexec@latest --template=react --yes
+npx claude-code-riskexec@latest --template=python --yes
+npx claude-code-riskexec@latest --template=nodejs --yes
 
 # Legacy syntax (still supported but deprecated)
-npx claude-code-templates@latest --language=javascript-typescript --framework=react
+npx claude-code-riskexec@latest --language=javascript-typescript --framework=react
 ```
 
 ### Individual Component Installation
@@ -32,9 +32,9 @@ Install specialized AI assistants using the `--agent` parameter:
 
 ```bash
 # Install specific agents
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --agent=api-security-audit --yes
-npx claude-code-templates@latest --agent=database-optimization --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --agent=api-security-audit --yes
+npx claude-code-riskexec@latest --agent=database-optimization --yes
 ```
 
 **Available agents include:**
@@ -48,9 +48,9 @@ Install custom slash commands using the `--command` parameter:
 
 ```bash
 # Install specific commands
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --command=generate-tests --yes
-npx claude-code-templates@latest --command=optimize-imports --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --command=generate-tests --yes
+npx claude-code-riskexec@latest --command=optimize-imports --yes
 ```
 
 **Manual installation (alternative method):**
@@ -60,7 +60,7 @@ mkdir -p .claude/commands
 
 # Install specific commands via direct download
 curl -o .claude/commands/check-file.md \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/commands/check-file.md
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/commands/utilities/check-file.md
 ```
 
 #### MCPs (🔌)
@@ -68,16 +68,16 @@ Install Model Context Protocol integrations using the `--mcp` parameter:
 
 ```bash
 # Install specific MCPs
-npx claude-code-templates@latest --mcp=github-integration --yes
-npx claude-code-templates@latest --mcp=database-integration --yes
-npx claude-code-templates@latest --mcp=deepgraph-react --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --mcp=database-integration --yes
+npx claude-code-riskexec@latest --mcp=deepgraph-react --yes
 ```
 
 **Manual installation (alternative method):**
 ```bash
 # GitHub integration
 curl -o ./github-integration.json \
-  https://raw.githubusercontent.com/davila7/claude-code-templates/main/components/mcps/github-integration.json
+  https://raw.githubusercontent.com/davila7/claude-code-riskexec/main/cli-tool/components/mcps/integration/github-integration.json
 ```
 
 ## Core Files Installed
@@ -110,7 +110,7 @@ curl -o ./github-integration.json \
 
 ```bash
 # Downloads complete template with multiple components
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 ```
 
 **Use Templates When:**
@@ -124,9 +124,9 @@ npx claude-code-templates@latest --template=react --yes
 
 ```bash
 # Downloads individual components to specific locations
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
 ```
 
 **Use Individual Components When:**
@@ -154,9 +154,9 @@ All templates and components are now downloaded directly from GitHub in real-tim
 You can discover and install components through:
 
 1. **CLI Parameters**: Use dedicated parameters (`--agent`, `--command`, `--mcp`, `--template`)
-2. **Web Interface**: Visit the [unified component browser](https://davila7.github.io/claude-code-templates/) to explore all available templates and components
-3. **Interactive CLI**: Run `npx claude-code-templates@latest` and select "⚙️ Project Setup"
-4. **GitHub Repository**: Browse components directly in the [repository structure](https://github.com/davila7/claude-code-templates)
+2. **Web Interface**: Visit the [unified component browser](https://davila7.github.io/claude-code-riskexec/) to explore all available templates and components
+3. **Interactive CLI**: Run `npx claude-code-riskexec@latest` and select "⚙️ Project Setup"
+4. **GitHub Repository**: Browse components directly in the [repository structure](https://github.com/davila7/claude-code-riskexec)
 
 ## Installation Paths
 

--- a/docu/docs/safety-features.md
+++ b/docu/docs/safety-features.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Safety Features
 
-`claude-code-templates` is designed with several safety features to ensure that your project and data are protected during the setup and configuration process.
+`claude-code-riskexec` is designed with several safety features to ensure that your project and data are protected during the setup and configuration process.
 
 -   **Automatic Backups**: Existing files are automatically backed up before any changes are made, allowing you to revert to a previous state if needed.
 -   **Confirmation Required**: The CLI always asks for your confirmation before making significant changes to your project (unless the `--yes` flag is used), giving you full control over the process.

--- a/docu/docs/support.md
+++ b/docu/docs/support.md
@@ -4,10 +4,10 @@ sidebar_position: 1
 
 # Support
 
-If you encounter any issues, have questions, or need assistance with `claude-code-templates`, please refer to the following resources:
+If you encounter any issues, have questions, or need assistance with `claude-code-riskexec`, please refer to the following resources:
 
--   **🐛 Issues**: [Report bugs or request features](https://github.com/davila7/claude-code-templates/issues)
--   **💬 Discussions**: [Join community discussions](https://github.com/davila7/claude-code-templates/discussions)
--   **🔒 Security**: [Report security vulnerabilities](https://github.com/davila7/claude-code-templates/blob/main/SECURITY.md)
+-   **🐛 Issues**: [Report bugs or request features](https://github.com/davila7/claude-code-riskexec/issues)
+-   **💬 Discussions**: [Join community discussions](https://github.com/davila7/claude-code-riskexec/discussions)
+-   **🔒 Security**: [Report security vulnerabilities](https://github.com/davila7/claude-code-riskexec/blob/main/SECURITY.md)
 -   **📖 Documentation**: [Claude Code Official Docs](https://docs.anthropic.com/en/docs/claude-code)
--   **🤝 Contributing**: [Read our contribution guidelines](https://github.com/davila7/claude-code-templates/blob/main/CONTRIBUTING.md)
+-   **🤝 Contributing**: [Read our contribution guidelines](https://github.com/davila7/claude-code-riskexec/blob/main/CONTRIBUTING.md)

--- a/docu/docs/usage-examples/advanced-options.md
+++ b/docu/docs/usage-examples/advanced-options.md
@@ -4,57 +4,57 @@ sidebar_position: 3
 
 # Advanced Options
 
-`claude-code-templates` provides several advanced command-line options for more granular control over its behavior.
+`claude-code-riskexec` provides several advanced command-line options for more granular control over its behavior.
 
 ## Template and Component Installation
 
 ```bash
 # Modern template installation (recommended)
-npx claude-code-templates@latest --template=react --yes
-npx claude-code-templates@latest --template=python --yes
+npx claude-code-riskexec@latest --template=react --yes
+npx claude-code-riskexec@latest --template=python --yes
 
 # Individual component installation
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
 
 # Legacy syntax (still supported but deprecated)
-npx claude-code-templates@latest --language=javascript-typescript --framework=react --yes
+npx claude-code-riskexec@latest --language=javascript-typescript --framework=react --yes
 ```
 
 ## Installation Control Options
 
 ```bash
 # Preview installation without making changes
-npx claude-code-templates@latest --dry-run
+npx claude-code-riskexec@latest --dry-run
 
 # Skip all prompts and use defaults
-npx claude-code-templates@latest --yes
+npx claude-code-riskexec@latest --yes
 
 # Install to custom directory
-npx claude-code-templates@latest --directory /path/to/project
+npx claude-code-riskexec@latest --directory /path/to/project
 ```
 
 ## System Analysis and Monitoring
 
 ```bash
 # Run comprehensive system health check
-npx claude-code-templates@latest --health-check
-npx claude-code-templates@latest --health
-npx claude-code-templates@latest --check
-npx claude-code-templates@latest --verify
+npx claude-code-riskexec@latest --health-check
+npx claude-code-riskexec@latest --health
+npx claude-code-riskexec@latest --check
+npx claude-code-riskexec@latest --verify
 
 # Analyze existing commands 
-npx claude-code-templates@latest --commands-stats
+npx claude-code-riskexec@latest --commands-stats
 
 # Analyze automation hooks
-npx claude-code-templates@latest --hooks-stats
+npx claude-code-riskexec@latest --hooks-stats
 
 # Analyze MCP server configurations 
-npx claude-code-templates@latest --mcps-stats
+npx claude-code-riskexec@latest --mcps-stats
 
 # Launch real-time analytics dashboard
-npx claude-code-templates@latest --analytics
+npx claude-code-riskexec@latest --analytics
 npx cct --analytics
 ```
 
@@ -63,16 +63,16 @@ npx cct --analytics
 ### Installing Multiple Components
 ```bash
 # Install multiple components in sequence
-npx claude-code-templates@latest --agent=react-performance --yes
-npx claude-code-templates@latest --command=check-file --yes
-npx claude-code-templates@latest --mcp=github-integration --yes
+npx claude-code-riskexec@latest --agent=react-performance --yes
+npx claude-code-riskexec@latest --command=check-file --yes
+npx claude-code-riskexec@latest --mcp=github-integration --yes
 ```
 
 ### Combining with Analysis
 ```bash
 # Install component and run stats
-npx claude-code-templates@latest --template=react --yes
-npx claude-code-templates@latest --commands-stats
+npx claude-code-riskexec@latest --template=react --yes
+npx claude-code-riskexec@latest --commands-stats
 ```
 
 ## GitHub Download System

--- a/docu/docs/usage-examples/alternative-commands.md
+++ b/docu/docs/usage-examples/alternative-commands.md
@@ -4,14 +4,14 @@ sidebar_position: 4
 
 # Alternative Commands
 
-`claude-code-templates` offers several alternative commands that perform the exact same function, providing flexibility and convenience.
+`claude-code-riskexec` offers several alternative commands that perform the exact same function, providing flexibility and convenience.
 
 ## Long Form Commands
 
 These commands are more descriptive and can be used interchangeably:
 
 ```bash
-npx claude-code-templates    # ✅ Recommended (package name)
+npx claude-code-riskexec    # ✅ Recommended (package name)
 npx claude-code-template     # Singular alias
 npx create-claude-config     # Create-style command
 npx claude-setup             # Setup-style command

--- a/docu/docs/usage-examples/framework-specific-quick-setup.md
+++ b/docu/docs/usage-examples/framework-specific-quick-setup.md
@@ -10,19 +10,19 @@ For a faster, non-interactive setup, you can use the modern `--template` paramet
 
 ```bash
 # React project
-npx claude-code-templates@latest --template=react --yes
+npx claude-code-riskexec@latest --template=react --yes
 
 # Python project  
-npx claude-code-templates@latest --template=python --yes
+npx claude-code-riskexec@latest --template=python --yes
 
 # Node.js project
-npx claude-code-templates@latest --template=nodejs --yes
+npx claude-code-riskexec@latest --template=nodejs --yes
 
 # Vue.js project
-npx claude-code-templates@latest --template=vue --yes
+npx claude-code-riskexec@latest --template=vue --yes
 
 # Django project
-npx claude-code-templates@latest --template=django --yes
+npx claude-code-riskexec@latest --template=django --yes
 ```
 
 ## Legacy Syntax (Still Supported)
@@ -31,10 +31,10 @@ The old `--language` and `--framework` parameters still work but are deprecated:
 
 ```bash
 # React + TypeScript project (legacy)
-npx claude-code-templates@latest --language=javascript-typescript --framework=react --yes
+npx claude-code-riskexec@latest --language=javascript-typescript --framework=react --yes
 
 # Python + Django project (legacy)
-npx claude-code-templates@latest --language=python --framework=django --yes
+npx claude-code-riskexec@latest --language=python --framework=django --yes
 ```
 
 ## Benefits of the New Syntax

--- a/docu/docs/usage-examples/interactive-setup.md
+++ b/docu/docs/usage-examples/interactive-setup.md
@@ -4,13 +4,13 @@ sidebar_position: 1
 
 # Interactive Setup
 
-This is the recommended way to start using `claude-code-templates`.
+This is the recommended way to start using `claude-code-riskexec`.
 
 Navigate to your project directory and run:
 
 ```bash
 cd your-project-directory
-npx claude-code-templates
+npx claude-code-riskexec
 ```
 
 This will launch an interactive wizard to guide you through the project setup and template installation. For a more detailed guide, refer to the [Interactive Project Setup](/docs/project-setup/interactive-setup) documentation.


### PR DESCRIPTION
## Summary
- replace `claude-code-templates` references with `claude-code-riskexec`
- fix direct component download links to point at `cli-tool` subpaths
- remove broken external link in hooks doc

## Testing
- `npm test`
- `npm --prefix docu run build`

------
https://chatgpt.com/codex/tasks/task_e_68c37aeff3588321a71b608c74824741