### PR TITLE
chore: remove aitmpl.com references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -484,10 +484,10 @@ npm start -- --dry-run
 ### Community Support
 - **GitHub Issues** - [Report bugs or request features](https://github.com/davila7/claude-code-riskexec/issues)
 - **GitHub Discussions** - [Join community discussions](https://github.com/davila7/claude-code-riskexec/discussions)
-- **Documentation** - [Complete guides at docs.aitmpl.com](https://docs.aitmpl.com/)
+- **Documentation** - [Complete guides at docs.riskexec.com](https://docs.riskexec.com/)
 
 ### Quick Start Guides
-- **Browse Components** - [aitmpl.com](https://aitmpl.com) to see existing components
+- **Browse Components** - [riskexec.com](https://riskexec.com) to see existing components
 - **Component Examples** - Check existing components for structure reference
 - **Template Examples** - Review successful templates for best practices
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,7 +37,7 @@ cat .vercel/project.json
 
 ## Deployment Flow
 
-- ✅ **Push to main** → Automatic production deploy to aitmpl.com
+- ✅ **Push to main** → Automatic production deploy to riskexec.com
 - ✅ **Other branches** → Manual deploy only (no auto-deploy)
 - ✅ **Pull Requests** → No deployment
 
@@ -55,6 +55,6 @@ vercel --prod
 
 ## Domain Configuration
 
-The main branch deploys to the custom domain: **aitmpl.com**
+The main branch deploys to the custom domain: **riskexec.com**
 
 Configured in Vercel dashboard under Project Settings → Domains.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 
 
-# Claude Code RiskExec (aitmpl.com)
+# Claude Code RiskExec (riskexec.com)
 
 **Ready-to-use configurations for Anthropic's Claude Code.** A comprehensive collection of AI agents, custom commands, settings, hooks, external integrations (MCPs), and project templates to enhance your development workflow.
 
 ## Browse & Install Components and Templates
 
-**[Browse All Templates](https://aitmpl.com)** - Interactive web interface to explore and install 100+ agents, commands, settings, hooks, and MCPs.
+**[Browse All Templates](https://riskexec.com)** - Interactive web interface to explore and install 100+ agents, commands, settings, hooks, and MCPs.
 
 <img width="1049" height="855" alt="Screenshot 2025-08-19 at 08 09 24" src="https://github.com/user-attachments/assets/e3617410-9b1c-4731-87b7-a3858800b737" />
 
@@ -78,11 +78,11 @@ npx claude-code-riskexec@latest --health-check
 
 ## 📖 Documentation
 
-**[📚 docs.aitmpl.com](https://docs.aitmpl.com/)** - Complete guides, examples, and API reference for all components and tools.
+**[📚 docs.riskexec.com](https://docs.riskexec.com/)** - Complete guides, examples, and API reference for all components and tools.
 
 ## Contributing
 
-We welcome contributions! **[Browse existing templates](https://aitmpl.com)** to see what's available, then check our [contributing guidelines](CONTRIBUTING.md) to add your own agents, commands, MCPs, settings, or hooks.
+We welcome contributions! **[Browse existing templates](https://riskexec.com)** to see what's available, then check our [contributing guidelines](CONTRIBUTING.md) to add your own agents, commands, MCPs, settings, or hooks.
 
 **Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.**
 
@@ -102,8 +102,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔗 Links
 
-- **🌐 Browse Templates**: [aitmpl.com](https://aitmpl.com)
-- **📚 Documentation**: [docs.aitmpl.com](https://docs.aitmpl.com)
+- **🌐 Browse Templates**: [riskexec.com](https://riskexec.com)
+- **📚 Documentation**: [docs.riskexec.com](https://docs.riskexec.com)
 - **💬 Community**: [GitHub Discussions](https://github.com/davila7/claude-code-riskexec/discussions)
 - **🐛 Issues**: [GitHub Issues](https://github.com/davila7/claude-code-riskexec/issues)
 

--- a/api/index.html
+++ b/api/index.html
@@ -1,1 +1,1 @@
-<h1>AITMPL.COM</h1>
+<h1>RiskExec.com</h1>

--- a/cli-tool/README.md
+++ b/cli-tool/README.md
@@ -97,18 +97,18 @@ The agents use the Claude Code SDK internally to provide specialized AI assistan
 
 ## 📖 Documentation
 
-**[📚 Complete Documentation](https://docs.aitmpl.com/)** - Comprehensive guides, examples, and API reference
+**[📚 Complete Documentation](https://docs.riskexec.com/)** - Comprehensive guides, examples, and API reference
 
 Quick links:
-- [Getting Started](https://docs.aitmpl.com/docs/intro) - Installation and first steps
-- [Project Setup](https://docs.aitmpl.com/docs/project-setup/interactive-setup) - Configure your projects
-- [Analytics Dashboard](https://docs.aitmpl.com/docs/analytics/overview) - Real-time monitoring
-- [Individual Components](https://docs.aitmpl.com/docs/components/overview) - Agents, Commands, MCPs
-- [CLI Options](https://docs.aitmpl.com/docs/cli-options) - All available commands
+- [Getting Started](https://docs.riskexec.com/docs/intro) - Installation and first steps
+- [Project Setup](https://docs.riskexec.com/docs/project-setup/interactive-setup) - Configure your projects
+- [Analytics Dashboard](https://docs.riskexec.com/docs/analytics/overview) - Real-time monitoring
+- [Individual Components](https://docs.riskexec.com/docs/components/overview) - Agents, Commands, MCPs
+- [CLI Options](https://docs.riskexec.com/docs/cli-options) - All available commands
 
 ## 🤝 Contributing
 
-We welcome contributions! Browse available templates and components at **[aitmpl.com](https://aitmpl.com)**, then check our [contributing guidelines](https://github.com/davila7/claude-code-templates/blob/main/CONTRIBUTING.md).
+We welcome contributions! Browse available templates and components at **[riskexec.com](https://riskexec.com)**, then check our [contributing guidelines](https://github.com/davila7/claude-code-templates/blob/main/CONTRIBUTING.md).
 
 ## 📄 License
 
@@ -116,8 +116,8 @@ MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## 🔗 Links
 
-- **🌐 Browse Components**: [aitmpl.com](https://aitmpl.com)
-- **📚 Documentation**: [docs.aitmpl.com](https://docs.aitmpl.com)
+- **🌐 Browse Components**: [riskexec.com](https://riskexec.com)
+- **📚 Documentation**: [docs.riskexec.com](https://docs.riskexec.com)
 - **🐛 Issues**: [GitHub Issues](https://github.com/davila7/claude-code-templates/issues)
 - **💬 Discussions**: [GitHub Discussions](https://github.com/davila7/claude-code-templates/discussions)
 

--- a/cli-tool/bin/create-claude-config.js
+++ b/cli-tool/bin/create-claude-config.js
@@ -36,8 +36,8 @@ function showBanner() {
   console.log(
     chalk.hex('#D97706')('🚀 Setup Claude Code for any project language 🚀') +
     chalk.gray(`\n                             v${pkg.version}\n\n`) +
-    chalk.blue('🌐 Templates: ') + chalk.underline('https://aitmpl.com') + '\n' +
-    chalk.blue('📖 Documentation: ') + chalk.underline('https://docs.aitmpl.com') + '\n'
+    chalk.blue('🌐 Templates: ') + chalk.underline('https://riskexec.com') + '\n' +
+    chalk.blue('📖 Documentation: ') + chalk.underline('https://docs.riskexec.com') + '\n'
   );
 }
 

--- a/cli-tool/src/index.js
+++ b/cli-tool/src/index.js
@@ -341,8 +341,8 @@ async function createClaudeConfig(options = {}) {
   console.log(chalk.white('  2. Customize the configuration for your project'));
   console.log(chalk.white('  3. Start using Claude Code with: claude'));
   console.log('');
-  console.log(chalk.blue('🌐 View all available templates at: https://aitmpl.com/'));
-  console.log(chalk.blue('📖 Read the complete documentation at: https://docs.aitmpl.com/'));
+  console.log(chalk.blue('🌐 View all available templates at: https://riskexec.com/'));
+  console.log(chalk.blue('📖 Read the complete documentation at: https://docs.riskexec.com/'));
   
   if (config.language !== 'common') {
     console.log(chalk.yellow(`💡 Language-specific features for ${config.language} have been configured`));
@@ -1247,23 +1247,23 @@ async function getAvailableAgentsFromGitHub() {
       }
     }
     
-    // Fallback to aitmpl.com API if local file not found
+    // Fallback to riskexec.com API if local file not found
     try {
-      // Try aitmpl.com API first
-      const apiResponse = await fetch('https://aitmpl.com/api/agents.json');
+      // Try riskexec.com API first
+      const apiResponse = await fetch('https://riskexec.com/api/agents.json');
       if (apiResponse.ok) {
         const apiData = await apiResponse.json();
         
         if (apiData.agents && Array.isArray(apiData.agents)) {
-          console.log(chalk.green(`✅ Loaded ${apiData.agents.length} agents from aitmpl.com API`));
+          console.log(chalk.green(`✅ Loaded ${apiData.agents.length} agents from riskexec.com API`));
           return apiData.agents;
         }
       }
     } catch (apiError) {
-      console.warn('Could not fetch from aitmpl.com, trying GitHub API...');
+      console.warn('Could not fetch from riskexec.com, trying GitHub API...');
     }
     
-    // If aitmpl.com API fails, try GitHub API as secondary fallback
+    // If riskexec.com API fails, try GitHub API as secondary fallback
     console.log(chalk.yellow('⚠️  Falling back to GitHub API...'));
     const response = await fetch('https://api.github.com/repos/davila7/claude-code-templates/contents/cli-tool/components/agents');
     if (!response.ok) {

--- a/cli-tool/src/tracking-service.js
+++ b/cli-tool/src/tracking-service.js
@@ -129,7 +129,7 @@ class TrackingService {
                 cliVersion: trackingData.environment?.cli_version || 'unknown'
             };
 
-            const response = await fetch('https://www.aitmpl.com/api/track-download-supabase', {
+            const response = await fetch('https://www.riskexec.com/api/track-download-supabase', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-aitmpl.com
+riskexec.com

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,7 @@
 title: Claude Code Templates
 description: Browse and install Claude Code configuration templates for different languages and frameworks
 baseurl: ""
-url: "https://aitmpl.com"
+url: "https://riskexec.com"
 
 # Build settings
 markdown: kramdown

--- a/docs/blog/e2b-claude-code-sandbox/index.html
+++ b/docs/blog/e2b-claude-code-sandbox/index.html
@@ -8,10 +8,10 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://aitmpl.com/blog/e2b-claude-code-sandbox/">
+    <meta property="og:url" content="https://riskexec.com/blog/e2b-claude-code-sandbox/">
     <meta property="og:title" content="E2B + Claude Code Sandbox: Secure Cloud Development Environment Guide">
     <meta property="og:description" content="Complete guide to run Claude Code in isolated E2B cloud sandbox. Install components safely, execute prompts in secure environment, and develop without local system risks.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png">
+    <meta property="og:image" content="https://www.riskexec.com/blog/assets/e2b-claude-code-sandbox-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:published_time" content="2025-01-31T10:00:00Z">
@@ -32,15 +32,15 @@
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/e2b-claude-code-sandbox/">
+    <meta property="twitter:url" content="https://riskexec.com/blog/e2b-claude-code-sandbox/">
     <meta property="twitter:title" content="E2B + Claude Code Sandbox: Secure Cloud Development Environment Guide">
     <meta property="twitter:description" content="Complete guide to run Claude Code in isolated E2B cloud sandbox. Install components safely, execute prompts in secure environment, and develop without local system risks.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png">
+    <meta property="twitter:image" content="https://www.riskexec.com/blog/assets/e2b-claude-code-sandbox-cover.png">
     
     <!-- Additional SEO -->
     <meta name="keywords" content="E2B Claude Code sandbox, cloud development environment, secure code execution, isolated development, Claude Code safety, E2B Python SDK, remote development, AI sandbox, secure AI development, cloud sandbox, development isolation, safe code generation">
     <meta name="author" content="Claude Code Templates">
-    <link rel="canonical" href="https://aitmpl.com/blog/e2b-claude-code-sandbox/">
+    <link rel="canonical" href="https://riskexec.com/blog/e2b-claude-code-sandbox/">
     
     <link rel="stylesheet" href="../../css/styles.css">
     <link rel="stylesheet" href="../../css/blog.css">
@@ -55,7 +55,7 @@
         "@type": "BlogPosting",
         "headline": "E2B + Claude Code Sandbox: Secure Cloud Development Environment Guide",
         "description": "Complete guide to run Claude Code in isolated E2B cloud sandbox. Install components safely, execute prompts in secure environment, and develop without local system risks.",
-        "image": "https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png",
+        "image": "https://www.riskexec.com/blog/assets/e2b-claude-code-sandbox-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -65,14 +65,14 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://www.riskexec.com/static/img/logo.svg"
             }
         },
         "datePublished": "2025-01-31T10:00:00Z",
         "dateModified": "2025-01-31T10:00:00Z",
         "mainEntityOfPage": {
             "@type": "WebPage",
-            "@id": "https://aitmpl.com/blog/e2b-claude-code-sandbox/"
+            "@id": "https://riskexec.com/blog/e2b-claude-code-sandbox/"
         },
         "keywords": "E2B Claude Code sandbox, cloud development environment, secure code execution, isolated development",
         "wordCount": "1800",
@@ -176,7 +176,7 @@
         </header>
 
         <article class="article-body">
-            <img src="https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png" alt="E2B and Claude Code Sandbox Integration" class="article-cover" loading="lazy">
+            <img src="https://www.riskexec.com/blog/assets/e2b-claude-code-sandbox-cover.png" alt="E2B and Claude Code Sandbox Integration" class="article-cover" loading="lazy">
             
             <div class="article-content-full">
                 <h2>Why Use Claude Code in a Sandbox?</h2>
@@ -275,7 +275,7 @@
 
                 <p>Before installing, explore the available sandbox components on the official Claude Code Templates website:</p>
 
-                <p>Visit <strong><a href="https://aitmpl.com" target="_blank" rel="noopener">aitmpl.com</a></strong> and search for "sandbox" to see all available cloud development environments.</p>
+                <p>Visit <strong><a href="https://riskexec.com" target="_blank" rel="noopener">riskexec.com</a></strong> and search for "sandbox" to see all available cloud development environments.</p>
                 
                 <!-- Newsletter CTA - Middle -->
                 <div class="newsletter-cta middle-newsletter">
@@ -666,7 +666,7 @@ npx claude-code-templates@latest --sandbox e2b \
                             </svg>
                             Trending
                         </a>
-                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">
+                        <a href="https://docs.riskexec.com/" target="_blank" class="footer-link">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
                             </svg>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -8,19 +8,19 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://aitmpl.com/blog/">
+    <meta property="og:url" content="https://riskexec.com/blog/">
     <meta property="og:title" content="Blog - Claude Code Templates">
     <meta property="og:description" content="Latest articles about Claude Code, AI development, and automation tools. Learn how to supercharge your development workflow with Anthropic's Claude Code.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta property="og:image" content="https://www.riskexec.com/blog/assets/supabase-claude-code-templates-cover.png">
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/">
+    <meta property="twitter:url" content="https://riskexec.com/blog/">
     <meta property="twitter:title" content="Blog - Claude Code Templates">
     <meta property="twitter:description" content="Latest articles about Claude Code, AI development, and automation tools.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta property="twitter:image" content="https://www.riskexec.com/blog/assets/supabase-claude-code-templates-cover.png">
     
-    <link rel="canonical" href="https://aitmpl.com/blog/">
+    <link rel="canonical" href="https://riskexec.com/blog/">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/blog.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -87,7 +87,7 @@
                     <article class="article-card">
                         <a href="blog/nextjs-vercel-claude-code-integration/" class="article-link">
                             <div class="article-image">
-                                <img src="https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png" alt="Next.js, Vercel and Claude Code Integration" loading="lazy">
+                                <img src="https://www.riskexec.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png" alt="Next.js, Vercel and Claude Code Integration" loading="lazy">
                                 <div class="article-category">Frontend</div>
                             </div>
                             <div class="article-content">
@@ -110,7 +110,7 @@
                     <article class="article-card">
                         <a href="blog/supabase-claude-code-integration/" class="article-link">
                             <div class="article-image">
-                                <img src="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png" alt="Supabase and Claude Code Integration" loading="lazy">
+                                <img src="https://www.riskexec.com/blog/assets/supabase-claude-code-templates-cover.png" alt="Supabase and Claude Code Integration" loading="lazy">
                                 <div class="article-category">Database</div>
                             </div>
                             <div class="article-content">
@@ -189,7 +189,7 @@
                             </svg>
                             Trending
                         </a>
-                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">
+                        <a href="https://docs.riskexec.com/" target="_blank" class="footer-link">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
                             </svg>

--- a/docs/blog/nextjs-vercel-claude-code-integration/index.html
+++ b/docs/blog/nextjs-vercel-claude-code-integration/index.html
@@ -8,10 +8,10 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://aitmpl.com/blog/nextjs-vercel-claude-code-integration/">
+    <meta property="og:url" content="https://riskexec.com/blog/nextjs-vercel-claude-code-integration/">
     <meta property="og:title" content="Next.js + Vercel + Claude Code Integration: Complete Guide with Agents, Commands and Hooks">
     <meta property="og:description" content="Complete guide to integrate Next.js and Vercel with Claude Code. Install 10 development commands, 3 specialized AI agents, and 5 automated hooks for Next.js deployment, optimization, and monitoring.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
+    <meta property="og:image" content="https://www.riskexec.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:published_time" content="2025-01-31T10:00:00Z">
@@ -32,15 +32,15 @@
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/nextjs-vercel-claude-code-integration/">
+    <meta property="twitter:url" content="https://riskexec.com/blog/nextjs-vercel-claude-code-integration/">
     <meta property="twitter:title" content="Next.js + Vercel + Claude Code Integration: Complete Guide with Agents, Commands and Hooks">
     <meta property="twitter:description" content="Complete guide to integrate Next.js and Vercel with Claude Code. Install 10 development commands, 3 specialized AI agents, and 5 automated hooks for Next.js deployment, optimization, and monitoring.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
+    <meta property="twitter:image" content="https://www.riskexec.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
     
     <!-- Additional SEO -->
     <meta name="keywords" content="Next.js Claude Code integration, Vercel Claude Code, Next.js AI development, Claude Code agents, Next.js automation, Vercel deployment hooks, React Claude Code, TypeScript automation, Next.js performance optimization, Vercel monitoring, AI-powered frontend development, Next.js best practices, Claude Code templates, Next.js deployment automation, Vercel error monitoring">
     <meta name="author" content="Claude Code Templates">
-    <link rel="canonical" href="https://aitmpl.com/blog/nextjs-vercel-claude-code-integration/">
+    <link rel="canonical" href="https://riskexec.com/blog/nextjs-vercel-claude-code-integration/">
     
     <link rel="stylesheet" href="../../css/styles.css">
     <link rel="stylesheet" href="../../css/blog.css">
@@ -55,7 +55,7 @@
         "@type": "BlogPosting",
         "headline": "Next.js + Vercel + Claude Code Integration: Complete Guide with Agents, Commands and Hooks",
         "description": "Complete guide to integrate Next.js and Vercel with Claude Code. Install 10 development commands, 3 specialized AI agents, and 5 automated hooks for Next.js deployment, optimization, and monitoring.",
-        "image": "https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png",
+        "image": "https://www.riskexec.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -65,14 +65,14 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://www.riskexec.com/static/img/logo.svg"
             }
         },
         "datePublished": "2025-01-31T10:00:00Z",
         "dateModified": "2025-01-31T10:00:00Z",
         "mainEntityOfPage": {
             "@type": "WebPage",
-            "@id": "https://aitmpl.com/blog/nextjs-vercel-claude-code-integration/"
+            "@id": "https://riskexec.com/blog/nextjs-vercel-claude-code-integration/"
         },
         "keywords": "Next.js Claude Code integration, Vercel deployment automation, React AI development, frontend optimization, TypeScript automation",
         "wordCount": "1500",
@@ -181,7 +181,7 @@
         </header>
 
         <article class="article-body">
-            <img src="https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png" alt="Next.js, Vercel and Claude Code Integration" class="article-cover" loading="lazy">
+            <img src="https://www.riskexec.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png" alt="Next.js, Vercel and Claude Code Integration" class="article-cover" loading="lazy">
             
             <div class="article-content-full">
                 <h2>Claude Code stack for Next.js and Vercel</h2>
@@ -336,13 +336,13 @@
                     </tbody>
                 </table>
 
-                <h2>Browse all components on AITMPL.com</h2>
+                <h2>Browse all components on RiskExec.com</h2>
 
                 <p>Before installing, you can explore all available Next.js and Vercel components on the official Claude Code Templates website:</p>
 
-                <p>Visit <strong><a href="https://aitmpl.com" target="_blank" rel="noopener">aitmpl.com</a></strong> and search for "nextjs" or "vercel" to see:</p>
+                <p>Visit <strong><a href="https://riskexec.com" target="_blank" rel="noopener">riskexec.com</a></strong> and search for "nextjs" or "vercel" to see:</p>
 
-                <img src="https://www.aitmpl.com/blog/assets/aitmpl-nextjs-search.png" alt="Searching for Next.js components on AITMPL.com" loading="lazy">
+                <img src="https://www.riskexec.com/blog/assets/riskexec-nextjs-search.png" alt="Searching for Next.js components on RiskExec.com" loading="lazy">
                 
                 <!-- Newsletter CTA - Middle -->
                 <div class="newsletter-cta middle-newsletter">
@@ -626,7 +626,7 @@ npx claude-code-templates@latest --setting statusline/vercel-multi-env-status
                             </svg>
                             Trending
                         </a>
-                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">
+                        <a href="https://docs.riskexec.com/" target="_blank" class="footer-link">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
                             </svg>

--- a/docs/blog/supabase-claude-code-integration/index.html
+++ b/docs/blog/supabase-claude-code-integration/index.html
@@ -8,10 +8,10 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://aitmpl.com/blog/supabase-claude-code-integration/">
+    <meta property="og:url" content="https://riskexec.com/blog/supabase-claude-code-integration/">
     <meta property="og:title" content="Supabase Claude Code Integration Guide: 8 Commands + AI Agents + MCP Server">
     <meta property="og:description" content="Complete guide to integrate Supabase with Claude Code. Install 8 database commands, 2 AI agents, and MCP server for automated schema design, migrations, and TypeScript generation.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta property="og:image" content="https://www.riskexec.com/blog/assets/supabase-claude-code-templates-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:published_time" content="2025-01-28T10:00:00Z">
@@ -32,15 +32,15 @@
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/supabase-claude-code-integration/">
+    <meta property="twitter:url" content="https://riskexec.com/blog/supabase-claude-code-integration/">
     <meta property="twitter:title" content="Supabase Claude Code Integration Guide: 8 Commands + AI Agents + MCP Server">
     <meta property="twitter:description" content="Complete guide to integrate Supabase with Claude Code. Install 8 database commands, 2 AI agents, and MCP server for automated schema design, migrations, and TypeScript generation.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta property="twitter:image" content="https://www.riskexec.com/blog/assets/supabase-claude-code-templates-cover.png">
     
     <!-- Additional SEO -->
     <meta name="keywords" content="Supabase Claude Code integration, MCP server Supabase, Claude Code agents, database development AI, Supabase schema architect, PostgreSQL Claude Code, AI database tools, Supabase automation, Claude Code templates, database migration assistant, Supabase TypeScript generator, real-time database monitoring, Supabase backup automation, database security audit, Anthropic Claude Code, AI-powered database development">
     <meta name="author" content="Claude Code Templates">
-    <link rel="canonical" href="https://aitmpl.com/blog/supabase-claude-code-integration/">
+    <link rel="canonical" href="https://riskexec.com/blog/supabase-claude-code-integration/">
     
     <link rel="stylesheet" href="../../css/styles.css">
     <link rel="stylesheet" href="../../css/blog.css">
@@ -55,7 +55,7 @@
         "@type": "BlogPosting",
         "headline": "Supabase Claude Code Integration Guide: 8 Commands + AI Agents + MCP Server",
         "description": "Complete guide to integrate Supabase with Claude Code. Install 8 database commands, 2 AI agents, and MCP server for automated schema design, migrations, and TypeScript generation.",
-        "image": "https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png",
+        "image": "https://www.riskexec.com/blog/assets/supabase-claude-code-templates-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -65,14 +65,14 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://www.riskexec.com/static/img/logo.svg"
             }
         },
         "datePublished": "2025-01-28T10:00:00Z",
         "dateModified": "2025-01-28T10:00:00Z",
         "mainEntityOfPage": {
             "@type": "WebPage",
-            "@id": "https://aitmpl.com/blog/supabase-claude-code-integration/"
+            "@id": "https://riskexec.com/blog/supabase-claude-code-integration/"
         },
         "keywords": "Supabase Claude Code integration, MCP server, database development AI, schema architect, TypeScript generator, database automation",
         "wordCount": "1200",
@@ -176,7 +176,7 @@
         </header>
 
         <article class="article-body">
-            <img src="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png" alt="Supabase and Claude Code Integration" class="article-cover" loading="lazy">
+            <img src="https://www.riskexec.com/blog/assets/supabase-claude-code-templates-cover.png" alt="Supabase and Claude Code Integration" class="article-cover" loading="lazy">
             
             <div class="article-content-full">
                 <h2>Claude Code stack for Supabase</h2>
@@ -263,13 +263,13 @@
                     </tbody>
                 </table>
 
-                <h2>Browse all components on AITMPL.com</h2>
+                <h2>Browse all components on RiskExec.com</h2>
 
                 <p>Before installing, you can explore all available Supabase components on the official Claude Code Templates website:</p>
 
-                <p>Visit <strong><a href="https://aitmpl.com" target="_blank" rel="noopener">aitmpl.com</a></strong> and search for "supabase" to see:</p>
+                <p>Visit <strong><a href="https://riskexec.com" target="_blank" rel="noopener">riskexec.com</a></strong> and search for "supabase" to see:</p>
 
-                <img src="https://www.aitmpl.com/blog/assets/aitmpl-supabase-search.png" alt="Searching for Supabase components on AITMPL.com" loading="lazy">
+                <img src="https://www.riskexec.com/blog/assets/riskexec-supabase-search.png" alt="Searching for Supabase components on RiskExec.com" loading="lazy">
                 
                 <!-- Newsletter CTA - Middle -->
                 <div class="newsletter-cta middle-newsletter">
@@ -442,7 +442,7 @@ npx claude-code-templates@latest \
                             </svg>
                             Trending
                         </a>
-                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">
+                        <a href="https://docs.riskexec.com/" target="_blank" class="footer-link">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
                             </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
                         Workflows
                     </a>
                     -->
-                    <a href="https://www.anthropic.com/claude-code?ref=aitmpl.com" target="_blank" class="header-btn anthropic-btn" title="Learn about Anthropic's Claude Code">
+                    <a href="https://www.anthropic.com/claude-code?ref=riskexec.com" target="_blank" class="header-btn anthropic-btn" title="Learn about Anthropic's Claude Code">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                         </svg>
@@ -447,7 +447,7 @@
                             </svg>
                             Trending
                         </a>
-                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">
+                        <a href="https://docs.riskexec.com/" target="_blank" class="footer-link">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
                             </svg>

--- a/docs/js/cart-manager.js
+++ b/docs/js/cart-manager.js
@@ -497,7 +497,7 @@ function shareOnTwitter() {
 Just run this command:
 ${command}
 
-Create yours at https://aitmpl.com`;
+Create yours at https://riskexec.com`;
     const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(message)}`;
     window.open(twitterUrl, '_blank');
     
@@ -512,7 +512,7 @@ function shareOnThreads() {
 Just run this command:
 ${command}
 
-Create yours at https://aitmpl.com`;
+Create yours at https://riskexec.com`;
     const threadsUrl = `https://threads.net/intent/post?text=${encodeURIComponent(message)}`;
     window.open(threadsUrl, '_blank');
     

--- a/docs/sandbox-interface.html
+++ b/docs/sandbox-interface.html
@@ -733,11 +733,11 @@
                 </div>
                 <div class="header-nav">
                     <div class="nav-links">
-                        <a href="https://www.anthropic.com/claude-code?ref=aitmpl.com" target="_blank" class="nav-link">
+                        <a href="https://www.anthropic.com/claude-code?ref=riskexec.com" target="_blank" class="nav-link">
                             Claude Code
                         </a>
                         <span class="nav-separator">|</span>
-                        <a href="https://aitmpl.com" target="_blank" class="nav-link">
+                        <a href="https://riskexec.com" target="_blank" class="nav-link">
                             Templates
                         </a>
                         <span class="nav-separator">|</span>

--- a/docs/trending.html
+++ b/docs/trending.html
@@ -123,7 +123,7 @@
                 <div class="footer-right">
                     <p class="footer-copyright">&copy; 2025 Claude Code Templates. Open source project.</p>
                     <div class="footer-links">
-                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">
+                        <a href="https://docs.riskexec.com/" target="_blank" class="footer-link">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
                             </svg>

--- a/docs/workflows.html
+++ b/docs/workflows.html
@@ -73,7 +73,7 @@
                     </a>
                 </div>
                 <div class="header-actions">
-                    <a href="https://docs.aitmpl.com/" target="_blank" class="header-btn">
+                    <a href="https://docs.riskexec.com/" target="_blank" class="header-btn">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
                         </svg>

--- a/docu/docs/components/hooks.md
+++ b/docu/docs/components/hooks.md
@@ -375,6 +375,6 @@ Want to create your own hook? Follow these guidelines:
 ---
 
 **Next Steps:**
-- [Browse All Hooks](https://aitmpl.com) - View available hooks in the web interface
+- [Browse All Hooks](https://riskexec.com) - View available hooks in the web interface
 - [Automation Hooks Guide →](../project-setup/automation-hooks) - Deep dive into automation workflows
 - [Contributing Guide →](../contributing) - Add your own hooks to the collection

--- a/docu/docs/components/overview.md
+++ b/docu/docs/components/overview.md
@@ -73,7 +73,7 @@ Hooks are powerful automation components that execute shell commands in response
 
 The **unified web interface** provides an intuitive way to browse and install individual components:
 
-To access the web interface, simply go to https://aitmpl.com
+To access the web interface, simply go to https://riskexec.com
 
 **Interface Features:**
 - **Unified Filter System**: Browse all component types (Templates, Agents, Commands, MCPs, Settings, Hooks) in a single view
@@ -280,4 +280,4 @@ The system welcomes community contributions! Each component type has "Add New" c
 - [Understand MCPs →](./mcps) - Integrate external services with Claude Code
 - [Configure Settings →](./settings) - Customize Claude Code behavior and preferences
 - [Automate with Hooks →](./hooks) - Set up event-driven automation workflows
-- [Browse All Components](https://aitmpl.com) - Visit the web interface
+- [Browse All Components](https://riskexec.com) - Visit the web interface

--- a/docu/docs/components/settings.md
+++ b/docu/docs/components/settings.md
@@ -219,5 +219,5 @@ Want to add a new setting? Follow these guidelines:
 
 **Next Steps:**
 - [Explore Hooks →](./hooks) - Learn about automation and event-driven actions
-- [Browse All Settings](https://aitmpl.com) - View available settings in the web interface
+- [Browse All Settings](https://riskexec.com) - View available settings in the web interface
 - [Contributing Guide →](../contributing) - Add your own settings to the collection

--- a/docu/docusaurus.config.ts
+++ b/docu/docusaurus.config.ts
@@ -6,7 +6,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Claude Code RiskExec',
-  tagline: 'Documentation for Claude Code RiskExec - AITMPL Platform',
+  tagline: 'Documentation for Claude Code RiskExec - RiskExec Platform',
   favicon: 'img/favicon.ico',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -15,7 +15,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://aitmpl.com',
+  url: 'https://riskexec.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For custom domain deployment
   baseUrl: '/',
@@ -85,7 +85,7 @@ const config: Config = {
     navbar: {
       title: 'Claude Code RiskExec',
       logo: {
-        alt: 'AITMPL Crystal Ball Logo',
+        alt: 'RiskExec Crystal Ball Logo',
         src: 'img/logo.svg',
       },
       items: [
@@ -96,7 +96,7 @@ const config: Config = {
           label: 'Documentation',
         },
         {
-          href: 'https://aitmpl.com/',
+          href: 'https://riskexec.com/',
           label: 'Browse Components',
           position: 'left',
         },
@@ -125,7 +125,7 @@ const config: Config = {
           items: [
             {
               label: 'Browse Components',
-              href: 'https://aitmpl.com/',
+              href: 'https://riskexec.com/',
             },
             {
               label: 'GitHub Repository',


### PR DESCRIPTION
## Summary
- replace legacy `aitmpl.com` links with `riskexec.com`
- update documentation, CLI messages and API fallback URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5ed0ecf78832183c12a583ca3c2ae