### PR TITLE
docs: remove attribution and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,6 @@ We welcome contributions! **[Browse existing templates](https://riskexec.com)** 
 
 **Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.**
 
-## Attribution
-
-This collection includes components from multiple sources:
-
-**Agents Collection:**
-- **wshobson/agents Collection** by [wshobson](https://github.com/wshobson/agents) - Licensed under MIT License (48 agents)
-
-**Commands Collection:**
-- **awesome-claude-code Commands** by [hesreallyhim](https://github.com/hesreallyhim/awesome-claude-code) - Licensed under CC0 1.0 Universal (21 commands)
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
 ## 🔗 Links
 
 - **🌐 Browse Templates**: [riskexec.com](https://riskexec.com)


### PR DESCRIPTION
## Summary
- remove attribution section from README
- drop redundant license section from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6346441208321b527d2e1425908d0