### PR TITLE
feat: add descriptive hook scripts

### DIFF
--- a/.claude/hooks/post-tool.output-log.json
+++ b/.claude/hooks/post-tool.output-log.json
@@ -1,0 +1,6 @@
+{
+  "name": "output-log",
+  "when": "post-tool",
+  "action": "command",
+  "command": "node_modules/.bin/ts-node scripts/hooks/log_tool_output.ts"
+}

--- a/.claude/hooks/pre-compact.transcript-backup.json
+++ b/.claude/hooks/pre-compact.transcript-backup.json
@@ -1,0 +1,6 @@
+{
+  "name": "transcript-backup",
+  "when": "pre-compact",
+  "action": "command",
+  "command": "node_modules/.bin/ts-node scripts/hooks/backup_transcript.ts --backup"
+}

--- a/.claude/hooks/pre-tool.command-safety.json
+++ b/.claude/hooks/pre-tool.command-safety.json
@@ -1,0 +1,6 @@
+{
+  "name": "command-safety",
+  "when": "pre-tool",
+  "action": "command",
+  "command": "node_modules/.bin/ts-node scripts/hooks/block_dangerous_commands.ts"
+}

--- a/.claude/hooks/session-start.context-loader.json
+++ b/.claude/hooks/session-start.context-loader.json
@@ -1,0 +1,6 @@
+{
+  "name": "context-loader",
+  "when": "session-start",
+  "action": "command",
+  "command": "node_modules/.bin/ts-node scripts/hooks/load_context.ts --load-context"
+}

--- a/.claude/hooks/user-prompt.prompt-audit.json
+++ b/.claude/hooks/user-prompt.prompt-audit.json
@@ -1,0 +1,6 @@
+{
+  "name": "prompt-audit",
+  "when": "user-prompt",
+  "action": "command",
+  "command": "node_modules/.bin/ts-node scripts/hooks/log_user_prompt.ts"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ coverage
 
 # Deployment
 .vercel
+
+# Hook logs
+logs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,11 @@
       },
       "devDependencies": {
         "@musistudio/claude-code-router": "^1.0.49",
+        "@types/node": "^20.11.30",
         "@vercel/node": "^3.0.0",
-        "front-matter": "^4.0.2"
+        "front-matter": "^4.0.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -866,9 +869,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA=="
+      "version": "20.19.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.14.tgz",
+      "integrity": "sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
@@ -879,6 +886,12 @@
         "@types/node": "*",
         "form-data": "^4.0.4"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/pg": {
       "version": "8.11.6",
@@ -954,6 +967,71 @@
         "ts-node": "10.9.1",
         "typescript": "4.9.5",
         "undici": "5.28.4"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@types/node": {
+      "version": "16.18.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
+      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/node/node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/node/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@vercel/postgres": {
@@ -5591,10 +5669,11 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5671,16 +5750,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
   "devDependencies": {
     "@musistudio/claude-code-router": "^1.0.49",
     "@vercel/node": "^3.0.0",
-    "front-matter": "^4.0.2"
+    "front-matter": "^4.0.2",
+    "@types/node": "^20.11.30",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
   },
   "keywords": [
     "claude-code",

--- a/scripts/hooks/backup_transcript.ts
+++ b/scripts/hooks/backup_transcript.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import { copyFileSync } from 'fs';
+
+function logPreCompact(inputData: any) {
+  const logDir = path.join(process.cwd(), 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  const logFile = path.join(logDir, 'pre_compact.json');
+  let logData: any[] = [];
+  if (fs.existsSync(logFile)) {
+    try { logData = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch { logData = []; }
+  }
+  logData.push(inputData);
+  fs.writeFileSync(logFile, JSON.stringify(logData, null, 2));
+}
+
+function backupTranscript(transcriptPath: string, trigger: string): string | null {
+  try {
+    if (!fs.existsSync(transcriptPath)) return null;
+    const backupDir = path.join(process.cwd(), 'logs', 'transcript_backups');
+    fs.mkdirSync(backupDir, { recursive: true });
+    const timestamp = new Date().toISOString().replace(/[-:T]/g,'').split('.')[0];
+    const sessionName = path.parse(transcriptPath).name;
+    const backupName = `${sessionName}_pre_compact_${trigger}_${timestamp}.jsonl`;
+    const backupPath = path.join(backupDir, backupName);
+    copyFileSync(transcriptPath, backupPath);
+    return backupPath;
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  try {
+    const args = process.argv.slice(2);
+    const doBackup = args.includes('--backup');
+    const verbose = args.includes('--verbose');
+    const inputData = JSON.parse(fs.readFileSync(0, 'utf8'));
+    const sessionId = inputData.session_id || 'unknown';
+    const transcriptPath = inputData.transcript_path || '';
+    const trigger = inputData.trigger || 'unknown';
+    const custom = inputData.custom_instructions || '';
+
+    logPreCompact(inputData);
+
+    let backupPath: string | null = null;
+    if (doBackup && transcriptPath) backupPath = backupTranscript(transcriptPath, trigger);
+
+    if (verbose) {
+      let message = trigger === 'manual'
+        ? `Preparing for manual compaction (session: ${sessionId.slice(0,8)}...)`
+        : `Auto-compaction triggered due to full context window (session: ${sessionId.slice(0,8)}...)`;
+      if (trigger === 'manual' && custom) {
+        message += `\nCustom instructions: ${custom.slice(0,100)}...`;
+      }
+      if (backupPath) message += `\nTranscript backed up to: ${backupPath}`;
+      console.log(message);
+    }
+
+    process.exit(0);
+  } catch {
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/hooks/block_dangerous_commands.ts
+++ b/scripts/hooks/block_dangerous_commands.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+
+function isDangerousRmCommand(command: string): boolean {
+  const normalized = command.toLowerCase().split(/\s+/).join(' ');
+  const patterns = [
+    /\brm\s+.*-[a-z]*r[a-z]*f/, // rm -rf
+    /\brm\s+.*-[a-z]*f[a-z]*r/, // rm -fr
+    /\brm\s+--recursive\s+--force/,
+    /\brm\s+--force\s+--recursive/,
+    /\brm\s+-r\s+.*-f/,
+    /\brm\s+-f\s+.*-r/
+  ];
+  for (const pattern of patterns) {
+    if (pattern.test(normalized)) return true;
+  }
+  if (/\brm\s+.*-[a-z]*r/.test(normalized)) {
+    const dangerousPaths = [
+      '/', '/\*', '~', '~/','$HOME', '..','*','.', '.\s*$'
+    ];
+    for (const p of dangerousPaths) {
+      if (new RegExp(p).test(normalized)) return true;
+    }
+  }
+  return false;
+}
+
+function isEnvFileAccess(toolName: string, toolInput: any): boolean {
+  if (['Read','Edit','MultiEdit','Write','Bash'].includes(toolName)) {
+    if (['Read','Edit','MultiEdit','Write'].includes(toolName)) {
+      const filePath = toolInput.file_path || '';
+      if (filePath.includes('.env') && !filePath.endsWith('.env.sample')) return true;
+    } else if (toolName === 'Bash') {
+      const command = toolInput.command || '';
+      const envPatterns = [
+        /\b\.env\b(?!\.sample)/,
+        /cat\s+.*\.env\b(?!\.sample)/,
+        /echo\s+.*>\s*\.env\b(?!\.sample)/,
+        /touch\s+.*\.env\b(?!\.sample)/,
+        /cp\s+.*\.env\b(?!\.sample)/,
+        /mv\s+.*\.env\b(?!\.sample)/
+      ];
+      for (const pattern of envPatterns) {
+        if (pattern.test(command)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function main() {
+  try {
+    const inputData = JSON.parse(fs.readFileSync(0, 'utf8'));
+    const toolName = inputData.tool_name || '';
+    const toolInput = inputData.tool_input || {};
+
+    if (isEnvFileAccess(toolName, toolInput)) {
+      console.error('BLOCKED: Access to .env files containing sensitive data is prohibited');
+      console.error('Use .env.sample for template files instead');
+      process.exit(2);
+    }
+
+    if (toolName === 'Bash') {
+      const command = toolInput.command || '';
+      if (isDangerousRmCommand(command)) {
+        console.error('BLOCKED: Dangerous rm command detected and prevented');
+        process.exit(2);
+      }
+    }
+
+    const logDir = path.join(process.cwd(), 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    const logPath = path.join(logDir, 'pre_tool_use.json');
+    let logData: any[] = [];
+    if (fs.existsSync(logPath)) {
+      try { logData = JSON.parse(fs.readFileSync(logPath, 'utf8')); } catch { logData = []; }
+    }
+    logData.push(inputData);
+    fs.writeFileSync(logPath, JSON.stringify(logData, null, 2));
+    process.exit(0);
+  } catch {
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/hooks/load_context.ts
+++ b/scripts/hooks/load_context.ts
@@ -1,0 +1,120 @@
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+function logSessionStart(inputData: any) {
+  const logDir = path.join(process.cwd(), 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  const logFile = path.join(logDir, 'session_start.json');
+  let logData: any[] = [];
+  if (fs.existsSync(logFile)) {
+    try { logData = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch { logData = []; }
+  }
+  logData.push(inputData);
+  fs.writeFileSync(logFile, JSON.stringify(logData, null, 2));
+}
+
+function getGitStatus(): [string|null, number|null] {
+  try {
+    const branch = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8', timeout: 5000 });
+    const currentBranch = branch.status === 0 ? branch.stdout.trim() : 'unknown';
+    const status = spawnSync('git', ['status', '--porcelain'], { encoding: 'utf8', timeout: 5000 });
+    let uncommitted = 0;
+    if (status.status === 0 && status.stdout.trim()) {
+      uncommitted = status.stdout.trim().split('\n').length;
+    }
+    return [currentBranch, uncommitted];
+  } catch {
+    return [null, null];
+  }
+}
+
+function getRecentIssues(): string | null {
+  try {
+    const ghCheck = spawnSync('which', ['gh']);
+    if (ghCheck.status !== 0) return null;
+    const result = spawnSync('gh', ['issue', 'list', '--limit', '5', '--state', 'open'], { encoding: 'utf8', timeout: 10000 });
+    if (result.status === 0 && result.stdout.trim()) return result.stdout.trim();
+  } catch { /* ignore */ }
+  return null;
+}
+
+function loadDevelopmentContext(source: string): string {
+  const contextParts: string[] = [];
+  contextParts.push(`Session started at: ${new Date().toISOString().replace('T',' ').split('.')[0]}`);
+  contextParts.push(`Session source: ${source}`);
+  const [branch, changes] = getGitStatus();
+  if (branch) {
+    contextParts.push(`Git branch: ${branch}`);
+    if (changes && changes > 0) contextParts.push(`Uncommitted changes: ${changes} files`);
+  }
+  const contextFiles = [
+    '.claude/CONTEXT.md',
+    '.claude/TODO.md',
+    'TODO.md',
+    '.github/ISSUE_TEMPLATE.md'
+  ];
+  for (const filePath of contextFiles) {
+    if (fs.existsSync(filePath)) {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8').trim();
+        if (content) {
+          contextParts.push(`\n--- Content from ${filePath} ---`);
+          contextParts.push(content.slice(0,1000));
+        }
+      } catch { /* ignore */ }
+    }
+  }
+  const issues = getRecentIssues();
+  if (issues) {
+    contextParts.push('\n--- Recent GitHub Issues ---');
+    contextParts.push(issues);
+  }
+  return contextParts.join('\n');
+}
+
+function main() {
+  try {
+    const args = process.argv.slice(2);
+    const loadCtx = args.includes('--load-context');
+    const announce = args.includes('--announce');
+    const inputData = JSON.parse(fs.readFileSync(0, 'utf8'));
+    const source = inputData.source || 'unknown';
+
+    logSessionStart(inputData);
+
+    if (loadCtx) {
+      const context = loadDevelopmentContext(source);
+      if (context) {
+        const output = {
+          hookSpecificOutput: {
+            hookEventName: 'SessionStart',
+            additionalContext: context
+          }
+        };
+        console.log(JSON.stringify(output));
+      }
+    }
+
+    if (announce) {
+      try {
+        const script = path.join(__dirname, 'utils', 'tts', 'pyttsx3_tts.py');
+        if (fs.existsSync(script)) {
+          const messages: Record<string,string> = {
+            startup: 'Claude Code session started',
+            resume: 'Resuming previous session',
+            clear: 'Starting fresh session'
+          };
+          const msg = messages[source] || 'Session started';
+          spawnSync('uv', ['run', script, msg], { timeout: 5000 });
+        }
+      } catch { /* ignore */ }
+    }
+
+    process.exit(0);
+  } catch {
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/hooks/log_tool_output.ts
+++ b/scripts/hooks/log_tool_output.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+
+function main() {
+  try {
+    const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+    const logDir = path.join(process.cwd(), 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    const logPath = path.join(logDir, 'post_tool_use.json');
+    let logData: any[] = [];
+    if (fs.existsSync(logPath)) {
+      try {
+        logData = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+      } catch {
+        logData = [];
+      }
+    }
+    logData.push(input);
+    fs.writeFileSync(logPath, JSON.stringify(logData, null, 2));
+    process.exit(0);
+  } catch {
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/hooks/log_user_prompt.ts
+++ b/scripts/hooks/log_user_prompt.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+interface SessionData {
+  session_id: string;
+  prompts: string[];
+  agent_name?: string;
+  [key: string]: any;
+}
+
+function logUserPrompt(sessionId: string, inputData: any) {
+  const logDir = path.join(process.cwd(), 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  const logFile = path.join(logDir, 'user_prompt_submit.json');
+  let logData: any[] = [];
+  if (fs.existsSync(logFile)) {
+    try { logData = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch { logData = []; }
+  }
+  logData.push(inputData);
+  fs.writeFileSync(logFile, JSON.stringify(logData, null, 2));
+}
+
+function manageSessionData(sessionId: string, prompt: string, nameAgent = false) {
+  const sessionsDir = path.join(process.cwd(), '.claude', 'data', 'sessions');
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  const sessionFile = path.join(sessionsDir, `${sessionId}.json`);
+  let sessionData: SessionData = { session_id: sessionId, prompts: [] };
+  if (fs.existsSync(sessionFile)) {
+    try { sessionData = JSON.parse(fs.readFileSync(sessionFile, 'utf8')); } catch { sessionData = { session_id: sessionId, prompts: [] }; }
+  }
+  sessionData.prompts = sessionData.prompts || [];
+  sessionData.prompts.push(prompt);
+  if (nameAgent && !sessionData.agent_name) {
+    try {
+      const result = execSync('uv run .claude/hooks/utils/llm/ollama.py --agent-name', { encoding: 'utf8', timeout: 5000 }).trim();
+      if (result && /^[A-Za-z0-9]+$/.test(result) && !result.includes(' ')) sessionData.agent_name = result;
+      else throw new Error('invalid');
+    } catch {
+      try {
+        const result = execSync('uv run .claude/hooks/utils/llm/anth.py --agent-name', { encoding: 'utf8', timeout: 10000 }).trim();
+        if (result && /^[A-Za-z0-9]+$/.test(result) && !result.includes(' ')) sessionData.agent_name = result;
+      } catch { /* ignore */ }
+    }
+  }
+  try { fs.writeFileSync(sessionFile, JSON.stringify(sessionData, null, 2)); } catch { /* ignore */ }
+}
+
+function validatePrompt(prompt: string): { valid: boolean; reason?: string } {
+  const blocked: Array<[RegExp, string]> = [];
+  const lower = prompt.toLowerCase();
+  for (const [pattern, reason] of blocked) {
+    if (pattern.test(lower)) return { valid: false, reason };
+  }
+  return { valid: true };
+}
+
+function main() {
+  try {
+    const args = process.argv.slice(2);
+    const hasFlag = (f: string) => args.includes(f);
+    const inputData = JSON.parse(fs.readFileSync(0, 'utf8'));
+    const sessionId = inputData.session_id || 'unknown';
+    const prompt = inputData.prompt || '';
+
+    logUserPrompt(sessionId, inputData);
+
+    if (hasFlag('--store-last-prompt') || hasFlag('--name-agent')) {
+      manageSessionData(sessionId, prompt, hasFlag('--name-agent'));
+    }
+
+    if (hasFlag('--validate') && !hasFlag('--log-only')) {
+      const { valid, reason } = validatePrompt(prompt);
+      if (!valid) {
+        console.error(`Prompt blocked: ${reason}`);
+        process.exit(2);
+      }
+    }
+
+    process.exit(0);
+  } catch {
+    process.exit(0);
+  }
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false
+  }
+}


### PR DESCRIPTION
## Summary
- convert hook utilities from Python to TypeScript and invoke them via ts-node
- log prompts, tool outputs, session context and transcript backups in TypeScript
- add TypeScript dev tooling for hook execution

## Testing
- `npm test`
- `npm run policy:models`


------
https://chatgpt.com/codex/tasks/task_e_68c60d4de6f48321abe935d18f66aa95