### PR TITLE
docs: add workflow overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ npx claude-code-riskexec@latest --hook pre-commit-validation
 npx claude-code-riskexec@latest --mcp postgresql-integration
 ```
 
+## 🔄 End-to-End Workflow
+
+```
+SpecKit → BMAD → CLI → Agent OS → Artifacts & Metrics
+```
+
+Run the entire pipeline with a single command when you need to orchestrate Spec Kit deliverables, BMAD phase automation, and Agent OS handoffs:
+
+```bash
+npx claude-code-riskexec --workflow Feature-X
+```
+
+The CLI drops Agent OS-ready bundles into `.agent-os/`, syncs live telemetry (artifacts, metrics, and run manifests), and pushes execution summaries back to your observability stack so downstream agents can reason over the latest context.
+
+- Dive deeper into the hands-on flow in [docs/usage/WORKFLOW_GUIDE.md](docs/usage/WORKFLOW_GUIDE.md).
+- Learn how the runtime contracts with Agent OS modules are wired in [docs/architecture/Agent%20OS%20Integration.md](docs/architecture/Agent%20OS%20Integration.md).
+
 ## What You Get
 
 | Component        | Description                                                                    | Examples                                                          |


### PR DESCRIPTION
## Summary
- add an end-to-end workflow overview and command to the README
- document Agent OS bundle and telemetry outputs and link to deeper guides

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68eab5bfee108321b50410224a5f2a86