### PR TITLE
fix: clear Agent OS destinations before mirroring

### DIFF
--- a/src/lib/agentOs.ts
+++ b/src/lib/agentOs.ts
@@ -61,16 +61,25 @@ export async function mirrorAgentOsDirectory(options: MirrorDirectoryOptions): P
 
   if (targetSubdir) {
     const destination = path.join(destinationRoot, targetSubdir);
+    if (fsExtra.pathExistsSync(destination)) {
+      fsExtra.removeSync(destination);
+    }
+    await ensureDir(path.dirname(destination));
     fsExtra.copySync(resolvedSource, destination, { overwrite: true, errorOnExist: false });
     mirroredEntries.push(...listPathsRelativeToRoot(destination, destinationRoot));
   } else {
     for (const artifact of PHASE_ARTIFACTS) {
       const sourcePath = path.join(resolvedSource, artifact);
+      const destination = path.join(destinationRoot, artifact);
+      if (fsExtra.pathExistsSync(destination)) {
+        fsExtra.removeSync(destination);
+      }
+
       if (!fsExtra.pathExistsSync(sourcePath)) {
         continue;
       }
 
-      const destination = path.join(destinationRoot, artifact);
+      await ensureDir(path.dirname(destination));
       fsExtra.copySync(sourcePath, destination, { overwrite: true, errorOnExist: false });
       mirroredEntries.push(...listPathsRelativeToRoot(destination, destinationRoot));
     }


### PR DESCRIPTION
## Summary
- extend `mirrorAgentOsDirectory` to copy spec, plan, tasks, and implementation artifacts into Agent OS using `fs-extra`
- add logging for mirrored entries and reuse the helper for existing directory mirroring
- cover the new behavior with unit tests for both targeted artifacts and explicit subdirectory mirroring
- clear Agent OS destination folders before mirroring so stale artifacts are removed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eab6d604a88321b56155a0bbefeb1b