### PR TITLE
Address Codex review feedback for core instruction guides

### DIFF
--- a/.agent-os/instructions/core/implement.mdc
+++ b/.agent-os/instructions/core/implement.mdc
@@ -8,9 +8,9 @@ See the [`implement` phase in spec_kit.yml](../../workflows/spec_kit.yml#L54-L69
 
 1. Run the mapped CLI command to begin implementation:
    ```bash
-   claude /implement "${FEATURE_NAME}" --plan "specs/${FEATURE_NAME}/plan.md" --tasks "specs/${FEATURE_NAME}/tasks.md"
+   claude /implement "${FEATURE_NAME}"
    ```
-   Include branch names or feature flags supplied by the coordinator.
+   Incorporate branch names or feature flags supplied by the coordinator via follow-up instructions.
 2. Wait until `specs/${FEATURE_NAME}/implementation/` is populated (commits, diffs, or notes) and confirm the CLI exits cleanly.
 3. Mirror the entire implementation directory into `.agent-os/product/${FEATURE_NAME}/specs/${FEATURE_NAME}/implementation/` using `rsync -a` so QA has access to artifacts.
 4. Append a JSON status entry with timestamps, repository references, and validation hashes to `.agent-os/product/${FEATURE_NAME}/logs/implement.jsonl`.

--- a/.agent-os/instructions/core/plan.mdc
+++ b/.agent-os/instructions/core/plan.mdc
@@ -8,9 +8,9 @@ See the [`plan` phase in spec_kit.yml](../../workflows/spec_kit.yml#L24-L37) for
 
 1. Run the mapped CLI command to generate the plan artifact:
    ```bash
-   claude /plan "${FEATURE_NAME}" --spec "specs/${FEATURE_NAME}/spec.md"
+   claude /plan "${FEATURE_NAME}"
    ```
-   Include any additional planner flags provided by the coordinator.
+   Provide any additional planner context requested by the coordinator through follow-up prompts.
 2. Wait for `specs/${FEATURE_NAME}/plan.md` to be created or updated before continuing.
 3. Mirror the result into product storage:
    ```bash

--- a/.agent-os/instructions/core/tasks.mdc
+++ b/.agent-os/instructions/core/tasks.mdc
@@ -8,9 +8,9 @@ See the [`tasks` phase in spec_kit.yml](../../workflows/spec_kit.yml#L38-L53) fo
 
 1. Run the mapped CLI command to produce the task list:
    ```bash
-   claude /tasks "${FEATURE_NAME}" --spec "specs/${FEATURE_NAME}/spec.md" --plan "specs/${FEATURE_NAME}/plan.md"
+   claude /tasks "${FEATURE_NAME}"
    ```
-   Pass through any prioritization or scheduling flags from the coordinator.
+   Capture any prioritization guidance from the coordinator through subsequent prompts.
 2. Wait until `specs/${FEATURE_NAME}/tasks.md` is written and verify the file contains at least one task entry.
 3. Mirror the task file to `.agent-os/product/${FEATURE_NAME}/specs/${FEATURE_NAME}/` so downstream phases can read it.
 4. Append a JSON status line with timestamps, owner assignments, and validation notes to `.agent-os/product/${FEATURE_NAME}/logs/tasks.jsonl`.

--- a/.agent-os/instructions/core/verify.mdc
+++ b/.agent-os/instructions/core/verify.mdc
@@ -8,13 +8,9 @@ See the [`verify` phase in spec_kit.yml](../../workflows/spec_kit.yml#L70-L89) f
 
 1. Run the mapped CLI command to launch the QA review:
    ```bash
-   claude /verify "${FEATURE_NAME}" \
-     --spec "specs/${FEATURE_NAME}/spec.md" \
-     --plan "specs/${FEATURE_NAME}/plan.md" \
-     --tasks "specs/${FEATURE_NAME}/tasks.md" \
-     --implementation "specs/${FEATURE_NAME}/implementation"
+   claude /verify "${FEATURE_NAME}"
    ```
-   Supply additional scope or evidence flags when requested by the coordinator.
+   Provide any additional context the coordinator requests via interactive prompts or follow-up commands.
 2. Wait until `specs/${FEATURE_NAME}/qa-report.md` is produced and confirm it contains pass/fail findings.
 3. Mirror the QA report (and any attached evidence directories) to `.agent-os/product/${FEATURE_NAME}/specs/${FEATURE_NAME}/` for archival.
 4. Append a JSON status entry with timestamps, verdict, and defect counts to `.agent-os/product/${FEATURE_NAME}/logs/verify.jsonl`.


### PR DESCRIPTION
## Summary
- update Spec Kit core phase guides to show the documented single-argument CLI invocations
- clarify that any extra context from the coordinator should be handled via follow-up prompts rather than unsupported flags

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eab6d907908321852c30a1a1c13317