### PR TITLE
Add docs quality workflow with link checks and preview artifacts

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -20,6 +20,8 @@ jobs:
             --no-progress
             --accept 429,403
             --verbose
+            --exclude http://localhost
+            --exclude https://localhost
             README.md
             docs/**/*.md
             docu/**/*.md


### PR DESCRIPTION
## Summary
- add a docs quality workflow that runs lychee against repository markdown files
- build the Docusaurus documentation site in CI and upload the static preview as an artifact for pull requests
- exclude localhost URLs from lychee link checking to avoid intentional local dashboard links failing CI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eab6e3de008321873412b229080f59