### PR TITLE
Fix Agent OS command map schema compatibility

### DIFF
--- a/.agent-os/command-map.json
+++ b/.agent-os/command-map.json
@@ -1,7 +1,42 @@
 {
-  "/create-spec": { "cli": "/specify", "agent": "bmad-analyst" },
-  "/plan-spec": { "cli": "/plan", "agent": "bmad-architect" },
-  "/create-tasks": { "cli": "/tasks", "agent": "bmad-pm" },
-  "/execute-tasks": { "cli": "/implement", "agent": "bmad-developer" },
-  "/verify-implementation": { "cli": "/verify", "agent": "bmad-qa" }
+  "implement": {
+    "agent": "bmad-developer",
+    "cliCommand": "/implement",
+    "agentOsCommand": "/execute-tasks",
+    "instruction": "core/implement.mdc",
+    "inputs": [
+      "specs/{feature}/plan.md",
+      "specs/{feature}/tasks.md"
+    ],
+    "output": "specs/{feature}/implementation"
+  },
+  "plan": {
+    "agent": "bmad-architect",
+    "cliCommand": "/plan",
+    "agentOsCommand": "/plan",
+    "instruction": "core/plan.mdc",
+    "inputs": [
+      "specs/{feature}/spec.md"
+    ],
+    "output": "specs/{feature}/plan.md"
+  },
+  "specify": {
+    "agent": "bmad-analyst",
+    "cliCommand": "/specify",
+    "agentOsCommand": "/create-spec",
+    "instruction": "core/specify.mdc",
+    "inputs": [],
+    "output": "specs/{feature}/spec.md"
+  },
+  "tasks": {
+    "agent": "bmad-pm",
+    "cliCommand": "/tasks",
+    "agentOsCommand": "/create-tasks",
+    "instruction": "core/tasks.mdc",
+    "inputs": [
+      "specs/{feature}/spec.md",
+      "specs/{feature}/plan.md"
+    ],
+    "output": "specs/{feature}/tasks.md"
+  }
 }


### PR DESCRIPTION
## Summary
- restore `.agent-os/command-map.json` to the phase-keyed schema expected by downstream scripts
- ensure each entry continues to map CLI commands to Agent OS commands with the required metadata fields

## Testing
- npm run agentos:verify

------
https://chatgpt.com/codex/tasks/task_e_68eab6dc215c832197dc4c528533c02f