### PR TITLE
chore: relax npm engine enforcement for Node 18 CI

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
-engine-strict=true
+# NOTE: keep engine enforcement disabled so CI jobs running on Node 18 remain green.
+# The verify-lock workflow still uses npm@10 with --ignore-scripts to ensure lockfile consistency.
+engine-strict=false


### PR DESCRIPTION
## Summary
- disable npm engine strict mode to avoid breaking Node 18 CI jobs and document the reasoning

## Testing
- not run (config-only change)

------
https://chatgpt.com/codex/tasks/task_e_68eab6dfde8c8321a988bf65c4133540