### PR TITLE
Clarify BMAD acronym in workflow guide

### DIFF
--- a/docs/usage/WORKFLOW_GUIDE.md
+++ b/docs/usage/WORKFLOW_GUIDE.md
@@ -1,6 +1,6 @@
 # Spec Kit Workflow Guide
 
-The RiskExec Spec Kit orchestrates software delivery through a structured Builder Methods → Agents → Deliverables (BMAD) pipeline. Each phase takes a well-defined input, prompts a specialized agent, and synchronizes the resulting artifact with Agent OS so product, engineering, and quality stakeholders share a single source of truth. This guide explains how to run the workflow end-to-end and where to find the generated outputs.
+The RiskExec Spec Kit orchestrates software delivery through a structured BMAD (Build, Measure, Analyze, Decide) pipeline with five dedicated agent roles (mapped to Analyst, Architect, PM, Developer, and QA respectively). Each phase takes a well-defined input, prompts a specialized agent, and synchronizes the resulting artifact with Agent OS so product, engineering, and quality stakeholders share a single source of truth. This guide explains how to run the workflow end-to-end and where to find the generated outputs.
 
 ## Pipeline Overview
 


### PR DESCRIPTION
## Summary
- define the BMAD acronym in the workflow guide introduction
- explain the five agent roles associated with the BMAD pipeline

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68ebf9a86a2483219cdea0260514d455